### PR TITLE
Workflow to run cron build of readthedocs

### DIFF
--- a/.github/workflows/readthedocs.yml
+++ b/.github/workflows/readthedocs.yml
@@ -1,0 +1,36 @@
+name: readthedocs
+
+on:
+  schedule:
+    # Runs "weekly at minute 01 before midnight Tuesday"
+      - cron: '53 23 * * 2'
+
+jobs:
+  tests:
+    name: tests
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.9
+          channels: conda-forge,defaults
+          channel-priority: strict
+          show-channel-urls: true
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+
+      - name: configure conda and install code
+        shell: bash -l {0}
+        run: |
+          mamba install --quiet \
+            --file=requirements.txt
+          python -m pip install --no-deps -e .
+          mamba install -y -q \
+            sphinx
+
+      - name: readthedocs
+        run: |
+          sphinx-build -T -E -b html -d docs/build/doctrees docs/source docs/build/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,8 +3,12 @@ version: 2
 sphinx:
   configuration: docs/source/conf.py
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
 python:
-  version: 3
   install:
     - method: pip
       path: .


### PR DESCRIPTION
The sphinx-build line has been tested interactively and works. The rest is cribbed from other functioning  workflows. 