### PR TITLE
Bug fixes to compute magnitudes

### DIFF
--- a/lsstdesc_diffsky/photometry/get_SEDs_from_SFH.py
+++ b/lsstdesc_diffsky/photometry/get_SEDs_from_SFH.py
@@ -50,7 +50,6 @@ def get_mag_sed_pars(
 
     cosmo_params = flat_wcdm.CosmoParams(cosmology.Om0, w0, wa,
                                          cosmology.H0.value/100)
-    gal_t_table = SED_params['lgt_table']
     print(
         ".....Evaluating mags & colors for {:.4f} <= z <= {:.4f}".format(
             np.min(gal_z_obs), np.max(gal_z_obs)
@@ -64,7 +63,7 @@ def get_mag_sed_pars(
             SED_params["ssp_obsmag_table"],
             SED_params["ssp_lgmet"],
             SED_params["ssp_lg_age_gyr"],
-            gal_t_table,
+            SED_params["t_table"],
             gal_z_obs,
             gal_log_sm,
             gal_sfr_table,

--- a/lsstdesc_diffsky/photometry/get_SFH_from_params.py
+++ b/lsstdesc_diffsky/photometry/get_SFH_from_params.py
@@ -69,7 +69,9 @@ def get_sfh_from_params(mah_params, ms_params, q_params, LGT0, t_table):
 
     """
 
-    print(".......computing SFHs from diffmah/star params for {} times".format(len(t_table)))
+    print(".......computing SFHs from diffmah/star params for {} times".format(
+        len(t_table))
+    )
     print(
         ".......using parameters with shapes {}, {}, {}".format(
             mah_params.shape, ms_params.shape, q_params.shape

--- a/lsstdesc_diffsky/write_mock_to_disk.py
+++ b/lsstdesc_diffsky/write_mock_to_disk.py
@@ -12,7 +12,6 @@ import gc
 import warnings
 import threading
 from time import time
-from jax import numpy as jnp
 from jax import random as jran
 from astropy.utils.misc import NumpyRNGContext
 from astropy.cosmology import FlatLambdaCDM, WMAP7
@@ -1361,7 +1360,7 @@ def generate_SEDs(
     dc2["sfr"] = sfr_obs
     log_ssfr = get_log_safe_ssfr(logsm_obs, sfr_obs)
     dc2["log_ssfr"] = log_ssfr
-    
+
     # generate metallicities
     lg_met_mean = mzr_model(logsm_obs, t_obs, *SED_params["met_params"])
     # lg_met_scatt = np.random.uniform(low=SED_params['lgmet_scatter_min'],
@@ -1381,7 +1380,8 @@ def generate_SEDs(
             alt_dustpop_params = SED_params["alt_dustpop_params"]
             print(".......with alt_dustpop_parameters")
             dust_params = mc_generate_dust_params(
-                ran_key, logsm_obs, log_ssfr, dc2["redshift"], tau_pdict=alt_dustpop_params
+                ran_key, logsm_obs, log_ssfr, dc2["redshift"],
+                tau_pdict=alt_dustpop_params,
             )
         else:
             dust_params = mc_generate_dust_params(


### PR DESCRIPTION
This PR includes some updates and corrections to the calls to the photometry kernels required to compute rest and observer frame magnitudes. Updates/corrections were also required to compute the observed stellar masses and SFRs from the new SFH table. This code now runs end-to-end and the results look reasonable.
