### PR TITLE
Add prototype kernel for disk/knot decomposition

### DIFF
--- a/lsstdesc_diffsky/disk_bulge_modeling/disk_knots.py
+++ b/lsstdesc_diffsky/disk_bulge_modeling/disk_knots.py
@@ -1,0 +1,51 @@
+"""
+"""
+from diffstar.stars import _integrate_sfr
+from dsps.constants import SFR_MIN
+from dsps.sed.stellar_age_weights import calc_age_weights_from_sfh_table
+from dsps.utils import _jax_get_dt_array
+from jax import jit as jjit
+from jax import numpy as jnp
+
+
+@jjit
+def _disk_knot_kern(
+    tarr, tobs, sfh, sfh_disk, fburst, fknot, age_weights_burst, ssp_lg_age_gyr
+):
+    sfh = jnp.where(sfh < SFR_MIN, SFR_MIN, sfh)
+    sfh_disk = jnp.where(sfh_disk < SFR_MIN, SFR_MIN, sfh_disk)
+
+    sfh_knot = fknot * sfh_disk
+    sfh_diffuse_disk = sfh_disk * (1 - fknot)
+
+    dtarr = _jax_get_dt_array(tarr)
+    smh = _integrate_sfr(sfh, dtarr)
+    smh_knot = _integrate_sfr(sfh_knot, dtarr)
+    smh_diffuse_disk = _integrate_sfr(sfh_diffuse_disk, dtarr)
+
+    age_weights_dd = calc_age_weights_from_sfh_table(
+        tarr, sfh_diffuse_disk, ssp_lg_age_gyr, tobs
+    )
+
+    lgt_table = jnp.log10(tarr)
+    mstar_tot = 10 ** jnp.interp(jnp.log10(tobs), lgt_table, jnp.log10(smh))
+    mknot = 10 ** jnp.interp(jnp.log10(tobs), lgt_table, jnp.log10(smh_knot))
+    mdd = 10 ** jnp.interp(jnp.log10(tobs), lgt_table, jnp.log10(smh_diffuse_disk))
+    mburst = fburst * mstar_tot
+
+    mburst_by_mknot = mburst / mknot
+    burst_knot_age_weights = (
+        mburst_by_mknot * age_weights_burst + (1 - mburst_by_mknot) * age_weights_dd
+    )
+    age_weights_knot = jnp.where(
+        mburst_by_mknot > 1, age_weights_burst, burst_knot_age_weights
+    )
+
+    mburst_dd = jnp.where(mburst_by_mknot > 1, mburst - mknot, 0.0)
+
+    mdd_tot = mdd + mburst_dd
+    age_weights_dd = (mdd / mdd_tot) * age_weights_dd + (
+        mburst_dd / mdd_tot
+    ) * age_weights_burst
+
+    return mstar_tot, mburst, mdd, mknot, age_weights_dd, age_weights_knot

--- a/lsstdesc_diffsky/disk_bulge_modeling/tests/test_disk_knots.py
+++ b/lsstdesc_diffsky/disk_bulge_modeling/tests/test_disk_knots.py
@@ -1,0 +1,44 @@
+"""
+"""
+import numpy as np
+from dsps.experimental.diffburst import DEFAULT_PARAMS, _age_weights_from_params
+from jax import random as jran
+
+from ..disk_knots import _disk_knot_kern
+
+
+def test_disk_knot_kern():
+    ran_key = jran.PRNGKey(0)
+
+    n_tests = 2_000
+    for __ in range(n_tests):
+        keys = jran.split(ran_key, 6)
+        ran_key, tobs_key, sfh_key, sfh_disk_key, burst_key, fknot_key = keys
+
+        nt = 100
+        tarr = np.linspace(0.1, 13.8, nt)
+        tobs = jran.uniform(tobs_key, minval=3, maxval=tarr[-1], shape=())
+        sfh = 10 ** jran.uniform(sfh_key, minval=3, maxval=2, shape=(nt,))
+        sfh_disk = jran.uniform(sfh_disk_key, shape=(nt,)) * sfh
+        fburst = 10 ** jran.uniform(burst_key, minval=-4, maxval=-2, shape=())
+        fknot = 10 ** jran.uniform(fknot_key, minval=-4, maxval=-0.5, shape=())
+
+        ssp_lg_age_yr = np.linspace(5, 10.5, 100)
+        age_weights_burst = _age_weights_from_params(ssp_lg_age_yr, DEFAULT_PARAMS)
+        assert np.allclose(1.0, age_weights_burst.sum(), rtol=0.01)
+
+        lg_gyr = ssp_lg_age_yr - 9.0
+        args = (tarr, tobs, sfh, sfh_disk, fburst, fknot, age_weights_burst, lg_gyr)
+        _res = _disk_knot_kern(*args)
+        mstar_tot, mburst, mdd, mknot, age_weights_dd, age_weights_knot = _res
+
+        mdisk = mdd + mknot
+        assert mdd < mstar_tot
+        assert np.allclose(mknot, mdisk * fknot, rtol=0.01)
+
+        assert np.allclose(1.0, age_weights_dd.sum(), rtol=0.01)
+        assert np.allclose(1.0, age_weights_knot.sum(), rtol=0.01)
+
+        ob_msk = ssp_lg_age_yr < 7
+        assert age_weights_knot[ob_msk].sum() > age_weights_dd[ob_msk].sum()
+        assert np.any(age_weights_knot[~ob_msk] < age_weights_dd[~ob_msk])


### PR DESCRIPTION
This PR brings in a new `disk_knots.py` module implementing prototype JAX kernels for decomposing the SFH of a disk into two components: one from bursty star-forming clouds, and another from the diffuse disk. Briefly, the way the decomposition works is as follows. In Diffsky, there is a smooth SFH that comes from Diffstar, and a possible burst just prior to the time of observation. In the new kernel `_disk_knot_kern`, the total stellar mass in the star-forming clouds is _first_ filled up with whatever is the burst mass, and then any remaining mass in the clouds comes from the Diffstar smooth SFH. In the event that the burst mass exceeds the mass in the star-forming clouds, any remaining burst mass goes into the diffuse disk, and the remainder of the diffuse disk mass comes from the Diffstar SFH. In this way, star-forming clouds will generally have younger stellar populations relative to the diffuse disk, but any difference between the two is exclusively driven by whatever is the burst mass assigned to the disk.

The plot below shows an example of the SED decomposition:
![example_disk_knot_sed](https://github.com/LSSTDESC/lsstdesc-diffsky/assets/6951595/5e6ac0e1-99e0-4f61-8ea4-b959ca2105dd)

In this plot, I generated 1000 random star formation histories and computed the colors separately of the diffuse disk and the clouds.
![disk_knot_colors](https://github.com/LSSTDESC/lsstdesc-diffsky/assets/6951595/d22edf74-b1c3-41e9-91a9-cae972f3deaa)
