### PR TITLE
Integrate disk/bulge/knot decomposition into SED pipeline

### DIFF
--- a/lsstdesc_diffsky/disk_bulge_modeling/disk_bulge_kernels.py
+++ b/lsstdesc_diffsky/disk_bulge_modeling/disk_bulge_kernels.py
@@ -152,18 +152,18 @@ def _bulge_fraction_vs_tform(t, t10, t90, params):
 
 
 @jjit
-def _bulge_sfh(tarr, sfh, params):
+def _bulge_sfh(tarr, sfh, fbulge_params):
     dtarr = _jax_get_dt_array(tarr)
     sfh = jnp.where(sfh < SFR_MIN, SFR_MIN, sfh)
     smh = _integrate_sfr(sfh, dtarr)
     fracmh = smh / smh[-1]
     t10 = jnp.interp(0.1, fracmh, tarr)
     t90 = jnp.interp(0.9, fracmh, tarr)
-    fbulge = _bulge_fraction_vs_tform(tarr, t10, t90, params)
-    sfh_bulge = fbulge * sfh
+    eff_bulge = _bulge_fraction_vs_tform(tarr, t10, t90, fbulge_params)
+    sfh_bulge = eff_bulge * sfh
     smh_bulge = _integrate_sfr(sfh_bulge, dtarr)
     bth = smh_bulge / smh
-    return smh, fbulge, sfh_bulge, smh_bulge, bth
+    return smh, eff_bulge, sfh_bulge, smh_bulge, bth
 
 
 DEFAULT_FBULGE_U_PARAMS = _get_u_params_from_params(

--- a/lsstdesc_diffsky/disk_bulge_modeling/disk_knots.py
+++ b/lsstdesc_diffsky/disk_bulge_modeling/disk_knots.py
@@ -6,6 +6,9 @@ from dsps.sed.stellar_age_weights import calc_age_weights_from_sfh_table
 from dsps.utils import _jax_get_dt_array
 from jax import jit as jjit
 from jax import numpy as jnp
+from jax import vmap
+
+FKNOT_MAX = 0.2
 
 
 @jjit
@@ -49,3 +52,7 @@ def _disk_knot_kern(
     ) * age_weights_burst
 
     return mstar_tot, mburst, mdd, mknot, age_weights_dd, age_weights_knot
+
+
+_V = (None, 0, 0, 0, 0, 0, 0, None)
+_disk_knot_vmap = jjit(vmap(_disk_knot_kern, in_axes=_V))

--- a/lsstdesc_diffsky/disk_bulge_modeling/mc_disk_bulge.py
+++ b/lsstdesc_diffsky/disk_bulge_modeling/mc_disk_bulge.py
@@ -37,7 +37,7 @@ def mc_disk_bulge(ran_key, tarr, sfh_pop):
     smh : ndarray, shape (n_gals, n_t)
         Stellar mass history of galaxy in units of Msun
 
-    fbulge : ndarray, shape (n_gals, n_t)
+    eff_bulge : ndarray, shape (n_gals, n_t)
         History of in-situ bulge growth efficiency for every galaxy
 
     sfh_bulge : ndarray, shape (n_gals, n_t)
@@ -61,8 +61,8 @@ def mc_disk_bulge(ran_key, tarr, sfh_pop):
     tcrit, fbulge_early, fbulge_late = fbulge_params
     params_pop = np.array((tcrit, fbulge_early, fbulge_late)).T
     _res = _bulge_sfh_vmap(tarr, sfh_pop, params_pop)
-    smh, fbulge, sfh_bulge, smh_bulge, bth = _res
-    return smh, fbulge, sfh_bulge, smh_bulge, bth
+    smh, eff_bulge, sfh_bulge, smh_bulge, bth = _res
+    return smh, eff_bulge, sfh_bulge, smh_bulge, bth
 
 
 def generate_frac_bulge_params(

--- a/lsstdesc_diffsky/disk_bulge_modeling/mc_disk_bulge.py
+++ b/lsstdesc_diffsky/disk_bulge_modeling/mc_disk_bulge.py
@@ -34,6 +34,11 @@ def mc_disk_bulge(ran_key, tarr, sfh_pop):
 
     Returns
     -------
+    fbulge_params : ndarray, shape (n_gals, 3)
+        tcrit_bulge = fbulge_params[:, 0]
+        fbulge_early = fbulge_params[:, 1]
+        fbulge_late = fbulge_params[:, 2]
+
     smh : ndarray, shape (n_gals, n_t)
         Stellar mass history of galaxy in units of Msun
 
@@ -57,15 +62,14 @@ def mc_disk_bulge(ran_key, tarr, sfh_pop):
     t90 = calc_tform_pop(tarr, smh_pop, 0.9)
     logsm0 = smh_pop[:, -1]
 
-    fbulge_params = generate_frac_bulge_params(ran_key, t10, t90, logsm0)
-    tcrit, fbulge_early, fbulge_late = fbulge_params
-    params_pop = np.array((tcrit, fbulge_early, fbulge_late)).T
-    _res = _bulge_sfh_vmap(tarr, sfh_pop, params_pop)
+    fbulge_params = generate_fbulge_params(ran_key, t10, t90, logsm0)
+
+    _res = _bulge_sfh_vmap(tarr, sfh_pop, fbulge_params)
     smh, eff_bulge, sfh_bulge, smh_bulge, bth = _res
-    return smh, eff_bulge, sfh_bulge, smh_bulge, bth
+    return fbulge_params, smh, eff_bulge, sfh_bulge, smh_bulge, bth
 
 
-def generate_frac_bulge_params(
+def generate_fbulge_params(
     ran_key,
     t10,
     t90,
@@ -105,7 +109,8 @@ def generate_frac_bulge_params(
     mc_u_late = jran.normal(late_key, shape=(n,)) * scale_u_late + mu_u_late_pop
 
     u_params = np.array((mc_u_tcrit, mc_u_early, mc_u_late)).T
-    tcrit, fbulge_early, fbulge_late = _get_params_from_u_params_vmap(
+    fbulge_tcrit, fbulge_early, fbulge_late = _get_params_from_u_params_vmap(
         u_params, t10, t90
     )
-    return tcrit, fbulge_early, fbulge_late
+    fbulge_params = np.array((fbulge_tcrit, fbulge_early, fbulge_late)).T
+    return fbulge_params

--- a/lsstdesc_diffsky/disk_bulge_modeling/tests/test_disk_knots.py
+++ b/lsstdesc_diffsky/disk_bulge_modeling/tests/test_disk_knots.py
@@ -4,7 +4,7 @@ import numpy as np
 from dsps.experimental.diffburst import DEFAULT_PARAMS, _age_weights_from_params
 from jax import random as jran
 
-from ..disk_knots import _disk_knot_kern
+from ..disk_knots import _disk_knot_kern, _disk_knot_vmap
 
 
 def test_disk_knot_kern():
@@ -42,3 +42,42 @@ def test_disk_knot_kern():
         ob_msk = ssp_lg_age_yr < 7
         assert age_weights_knot[ob_msk].sum() > age_weights_dd[ob_msk].sum()
         assert np.any(age_weights_knot[~ob_msk] < age_weights_dd[~ob_msk])
+        assert np.any(age_weights_knot[~ob_msk] < age_weights_dd[~ob_msk])
+
+
+def test_disk_knot_vmap():
+    ran_key = jran.PRNGKey(0)
+    keys = jran.split(ran_key, 6)
+    ran_key, tobs_key, sfh_key, sfh_disk_key, burst_key, fknot_key = keys
+
+    nt = 100
+    tarr = np.linspace(0.1, 13.8, nt)
+
+    n_gals = 10
+
+    tobs = jran.uniform(tobs_key, minval=3, maxval=tarr[-1], shape=(n_gals,))
+    sfh = 10 ** jran.uniform(sfh_key, minval=3, maxval=2, shape=(n_gals, nt))
+    sfh_disk = jran.uniform(sfh_disk_key, shape=(n_gals, nt)) * sfh
+    fburst = 10 ** jran.uniform(burst_key, minval=-4, maxval=-2, shape=(n_gals,))
+    fknot = 10 ** jran.uniform(fknot_key, minval=-4, maxval=-0.5, shape=(n_gals,))
+
+    n_age = 100
+    ssp_lg_age_yr = np.linspace(5, 10.5, n_age)
+    age_weights_singleburst = _age_weights_from_params(ssp_lg_age_yr, DEFAULT_PARAMS)
+    age_weights_burstpop = np.tile(age_weights_singleburst, n_gals)
+    age_weights_burstpop = age_weights_burstpop.reshape((n_gals, n_age))
+
+    lg_gyr = ssp_lg_age_yr - 9.0
+    args = (tarr, tobs, sfh, sfh_disk, fburst, fknot, age_weights_burstpop, lg_gyr)
+    _res = _disk_knot_vmap(*args)
+    for _x in _res:
+        assert np.all(np.isfinite(_x))
+
+    mstar_tot, mburst, mdd, mknot, age_weights_dd, age_weights_knot = _res
+    assert mstar_tot.shape == (n_gals,)
+    assert mburst.shape == (n_gals,)
+    assert mdd.shape == (n_gals,)
+    assert mknot.shape == (n_gals,)
+    assert age_weights_dd.shape == (n_gals, n_age)
+    assert age_weights_knot.shape == (n_gals, n_age)
+    assert np.all(mstar_tot > mdd + mknot)

--- a/lsstdesc_diffsky/disk_bulge_modeling/tests/test_mc_disk_bulge.py
+++ b/lsstdesc_diffsky/disk_bulge_modeling/tests/test_mc_disk_bulge.py
@@ -9,7 +9,7 @@ from jax import random as jran
 from jax import vmap
 
 from ..disk_bulge_kernels import FBULGE_MAX, FBULGE_MIN, calc_tform_pop
-from ..mc_disk_bulge import _bulge_sfh_vmap, generate_frac_bulge_params, mc_disk_bulge
+from ..mc_disk_bulge import _bulge_sfh_vmap, generate_fbulge_params, mc_disk_bulge
 
 _B = (0, None)
 _integrate_sfr_vmap = jjit(vmap(_integrate_sfr, in_axes=_B))
@@ -33,14 +33,11 @@ def test_mc_disk_bulge_component_functions_work_together():
     t90 = calc_tform_pop(tarr, smh_pop, 0.9)
     logsm0 = smh_pop[:, -1]
 
-    fbulge_params = generate_frac_bulge_params(ran_key_fbulge, t10, t90, logsm0)
-    tcrit, fbulge_early, fbulge_late = fbulge_params
-    for param in fbulge_params:
-        assert param.shape == (n_gals,)
-        assert np.all(np.isfinite(param))
+    fbulge_params = generate_fbulge_params(ran_key_fbulge, t10, t90, logsm0)
+    assert fbulge_params.shape == (n_gals, 3)
+    assert np.all(np.isfinite(fbulge_params))
 
-    params_pop = np.array((tcrit, fbulge_early, fbulge_late)).T
-    _res = _bulge_sfh_vmap(tarr, ran_sfh_pop, params_pop)
+    _res = _bulge_sfh_vmap(tarr, ran_sfh_pop, fbulge_params)
     for x in _res:
         assert np.all(np.isfinite(x))
 
@@ -69,9 +66,11 @@ def test_mc_disk_bulge():
     ran_sfh_pop = jran.uniform(ran_key_sfh, minval=0, maxval=100, shape=(n_gals, n_t))
 
     _res = mc_disk_bulge(ran_key, tarr, ran_sfh_pop)
-    smh_pop, fbulge, sfh_bulge, smh_bulge, bth = _res
+    fbulge_params, smh_pop, fbulge, sfh_bulge, smh_bulge, bth = _res
     assert smh_pop.shape == (n_gals, n_t)
     assert fbulge.shape == (n_gals, n_t)
+    assert fbulge_params.shape == (n_gals, 3)
+
     assert np.all(fbulge > FBULGE_MIN)
     assert np.all(fbulge < FBULGE_MAX)
 

--- a/lsstdesc_diffsky/photometry/photometry_lc_interp.py
+++ b/lsstdesc_diffsky/photometry/photometry_lc_interp.py
@@ -14,10 +14,22 @@ from dsps.cosmology.flat_wcdm import _age_at_z_vmap
 from dsps.experimental.diffburst import _age_weights_from_u_params
 from dsps.metallicity.mzr import DEFAULT_MZR_PDICT, mzr_model
 from dsps.sed import calc_ssp_weights_sfh_table_lognormal_mdf
-from dsps.sed.stellar_age_weights import _calc_logsm_table_from_sfh_table
+from dsps.sed.stellar_age_weights import (
+    _calc_logsm_table_from_sfh_table,
+    calc_age_weights_from_sfh_table,
+)
 from jax import jit as jjit
 from jax import numpy as jnp
+from jax import random as jran
 from jax import vmap
+
+from ..disk_bulge_modeling.disk_knots import FKNOT_MAX, _disk_knot_vmap
+from ..disk_bulge_modeling.mc_disk_bulge import mc_disk_bulge
+
+_D = (None, 0, None, 0)
+calc_age_weights_from_sfh_table_vmap = jjit(
+    vmap(calc_age_weights_from_sfh_table, in_axes=_D)
+)
 
 _linterp_vmap = jjit(vmap(jnp.interp, in_axes=(0, None, 0)))
 
@@ -60,61 +72,26 @@ def get_diffsky_sed_info(
     met_params=DEFAULT_MZR_PARAMS,
     lgmet_scatter=0.2,
 ):
-    msg = "ssp_z_table must be monotonically increasing"
-    assert jnp.all(jnp.diff(ssp_z_table) > 0), msg
+    _check_ssp_info_shapes(ssp_z_table, gal_z_obs)
 
-    msg = "Must have ssp_z_table.min() < gal_z_obs.min()"
-    assert jnp.all(ssp_z_table.min() < gal_z_obs.min()), msg
-
-    msg = "Must have ssp_z_table.max() > gal_z_obs.max()"
-    assert jnp.all(ssp_z_table.max() > gal_z_obs.max()), msg
-
-    ssp_obsmag_table_pergal = interpolate_ssp_photmag_table(
-        gal_z_obs, ssp_z_table, ssp_obsmag_table
+    ssp_obsmag_table_pergal = _get_ssp_obsmag_table_pergal(
+        gal_z_obs, ssp_z_table, ssp_obsmag_table, ssp_restmag_table, gal_sfr_table
     )
-    n_gals, n_met, n_age, n_obs_filters = ssp_obsmag_table_pergal.shape
     ssp_obsflux_table_pergal = 10 ** (-0.4 * ssp_obsmag_table_pergal)
     ssp_restflux_table = 10 ** (-0.4 * ssp_restmag_table)
 
-    msg = "gal_sfr_table.shape[0]={0} must equal gal_z_obs.shape[0]={1}"
-    _n_gals = gal_sfr_table.shape[0]
-    assert n_gals == gal_sfr_table.shape[0], msg.format(n_gals, _n_gals)
+    n_gals, n_met, n_age, n_obs_filters = ssp_obsmag_table_pergal.shape
+    n_rest_filters = ssp_restmag_table.shape[-1]
 
-    msg = "ssp_lgmet.shape[0]={0} must equal ssp_obsmag_table_pergal.shape[1]={1}"
-    _n_met = ssp_obsmag_table_pergal.shape[1]
-    assert n_met == _n_met, msg.format(n_met, _n_met)
-
-    msg = "ssp_lg_age_gyr.shape[0]={0} must equal ssp_obsmag_table_pergal.shape[2]={1}"
-    _n_age = ssp_obsmag_table_pergal.shape[2]
-    assert n_age == _n_age, msg.format(n_age, _n_age)
-
-    n_met2, n_age2, n_rest_filters = ssp_restmag_table.shape
-    msg = "ssp_obsmag_table.shape[1]={0} must equal ssp_restmag_table.shape[0]={1}"
-    assert n_met == n_met2, msg.format(n_met, n_met2)
-
-    msg = "ssp_obsmag_table.shape[2]={0} must equal ssp_restmag_table.shape[1]={1}"
-    assert n_age == n_age2, msg.format(n_age, n_age2)
-
-    gal_t_obs = _age_at_z_vmap(gal_z_obs, *cosmo_params)
-    lgt_obs = jnp.log10(gal_t_obs)
-    lgt_table = jnp.log10(gal_t_table)
-
-    gal_sfr_table = jnp.where(gal_sfr_table < SFR_MIN, SFR_MIN, gal_sfr_table)
-    gal_logsm_table = _calc_logsm_table_from_sfh_table_vmap(
-        gal_t_table, gal_sfr_table, SFR_MIN
+    _res = _get_galprops_at_t_obs(
+        gal_z_obs, gal_t_table, gal_sfr_table, met_params, cosmo_params
     )
-    gal_logsfr_table = jnp.log10(gal_sfr_table)
-
-    gal_logsm_t_obs = _linterp_vmap(lgt_obs, lgt_table, gal_logsm_table)
-    gal_logsfr_t_obs = _linterp_vmap(lgt_obs, lgt_table, gal_logsfr_table)
-    gal_logssfr_t_obs = gal_logsfr_t_obs - gal_logsm_t_obs
-
-    gal_lgmet = mzr_model(gal_logsm_t_obs, gal_t_obs, *met_params[:-1])
+    gal_t_obs, gal_logsm_t_obs, gal_logssfr_t_obs, gal_lgmet_t_obs = _res
 
     args = (
         gal_t_table,
         gal_sfr_table,
-        gal_lgmet,
+        gal_lgmet_t_obs,
         lgmet_scatter,
         ssp_lgmet,
         ssp_lg_age_gyr,
@@ -212,3 +189,107 @@ def get_diffsky_sed_info(
         gal_obsmags_dust,
         gal_restmags_dust,
     )
+
+
+def decompose_sfh_into_bulge_disk_knots(
+    ran_key, gal_t_obs, gal_t_table, gal_sfh, fburst, age_weights_burst, ssp_lg_age_gyr
+):
+    bulge_key, knot_key = jran.split(ran_key, 2)
+
+    gal_smh, eff_bulge, bulge_sfh, bulge_smh, bth = mc_disk_bulge(
+        bulge_key, gal_t_table, gal_sfh
+    )
+    bulge_sfh = jnp.where(bulge_sfh < SFR_MIN, SFR_MIN, bulge_sfh)
+    frac_bulge_t_obs = _linterp_vmap(gal_t_obs, gal_t_table, bth)
+
+    bulge_age_weights = calc_age_weights_from_sfh_table_vmap(
+        gal_t_table, bulge_sfh, ssp_lg_age_gyr, gal_t_obs
+    )
+
+    disk_sfh = gal_sfh - bulge_sfh
+    disk_sfh = jnp.where(disk_sfh < SFR_MIN, SFR_MIN, disk_sfh)
+
+    n_gals = gal_sfh.shape[0]
+    fknot = jran.uniform(knot_key, minval=0, maxval=FKNOT_MAX, shape=(n_gals,))
+
+    args = (
+        gal_t_table,
+        gal_t_obs,
+        gal_sfh,
+        disk_sfh,
+        fburst,
+        fknot,
+        age_weights_burst,
+        ssp_lg_age_gyr,
+    )
+    _res = _disk_knot_vmap(*args)
+    mstar_tot, mburst, mdd, mknot, dd_age_weights, knot_age_weights = _res
+
+    mbulge = frac_bulge_t_obs * mstar_tot
+    masses = mbulge, mdd, mknot, mburst
+    age_weights = bulge_age_weights, dd_age_weights, knot_age_weights
+    ret = (*masses, *age_weights)
+    return ret
+
+
+def _get_galprops_at_t_obs(
+    gal_z_obs, gal_t_table, gal_sfr_table, met_params, cosmo_params
+):
+    gal_t_obs = _age_at_z_vmap(gal_z_obs, *cosmo_params)
+    lgt_obs = jnp.log10(gal_t_obs)
+    lgt_table = jnp.log10(gal_t_table)
+
+    gal_sfr_table = jnp.where(gal_sfr_table < SFR_MIN, SFR_MIN, gal_sfr_table)
+    gal_logsm_table = _calc_logsm_table_from_sfh_table_vmap(
+        gal_t_table, gal_sfr_table, SFR_MIN
+    )
+    gal_logsfr_table = jnp.log10(gal_sfr_table)
+
+    gal_logsm_t_obs = _linterp_vmap(lgt_obs, lgt_table, gal_logsm_table)
+    gal_logsfr_t_obs = _linterp_vmap(lgt_obs, lgt_table, gal_logsfr_table)
+    gal_logssfr_t_obs = gal_logsfr_t_obs - gal_logsm_t_obs
+
+    gal_lgmet_t_obs = mzr_model(gal_logsm_t_obs, gal_t_obs, *met_params[:-1])
+
+    return gal_t_obs, gal_logsm_t_obs, gal_logssfr_t_obs, gal_lgmet_t_obs
+
+
+def _check_ssp_info_shapes(ssp_z_table, gal_z_obs):
+    msg = "ssp_z_table must be monotonically increasing"
+    assert jnp.all(jnp.diff(ssp_z_table) > 0), msg
+
+    msg = "Must have ssp_z_table.min() < gal_z_obs.min()"
+    assert jnp.all(ssp_z_table.min() < gal_z_obs.min()), msg
+
+    msg = "Must have ssp_z_table.max() > gal_z_obs.max()"
+    assert jnp.all(ssp_z_table.max() > gal_z_obs.max()), msg
+
+
+def _get_ssp_obsmag_table_pergal(
+    gal_z_obs, ssp_z_table, ssp_obsmag_table, ssp_restmag_table, gal_sfr_table
+):
+    ssp_obsmag_table_pergal = interpolate_ssp_photmag_table(
+        gal_z_obs, ssp_z_table, ssp_obsmag_table
+    )
+    n_gals, n_met, n_age, n_obs_filters = ssp_obsmag_table_pergal.shape
+
+    msg = "gal_sfr_table.shape[0]={0} must equal gal_z_obs.shape[0]={1}"
+    _n_gals = gal_sfr_table.shape[0]
+    assert n_gals == gal_sfr_table.shape[0], msg.format(n_gals, _n_gals)
+
+    msg = "ssp_lgmet.shape[0]={0} must equal ssp_obsmag_table_pergal.shape[1]={1}"
+    _n_met = ssp_obsmag_table_pergal.shape[1]
+    assert n_met == _n_met, msg.format(n_met, _n_met)
+
+    msg = "ssp_lg_age_gyr.shape[0]={0} must equal ssp_obsmag_table_pergal.shape[2]={1}"
+    _n_age = ssp_obsmag_table_pergal.shape[2]
+    assert n_age == _n_age, msg.format(n_age, _n_age)
+
+    n_met2, n_age2, n_rest_filters = ssp_restmag_table.shape
+    msg = "ssp_obsmag_table.shape[1]={0} must equal ssp_restmag_table.shape[0]={1}"
+    assert n_met == n_met2, msg.format(n_met, n_met2)
+
+    msg = "ssp_obsmag_table.shape[2]={0} must equal ssp_restmag_table.shape[1]={1}"
+    assert n_age == n_age2, msg.format(n_age, n_age2)
+
+    return ssp_obsmag_table_pergal

--- a/lsstdesc_diffsky/photometry/photometry_lc_interp.py
+++ b/lsstdesc_diffsky/photometry/photometry_lc_interp.py
@@ -1,4 +1,11 @@
-"""
+"""Module implements two functions:
+
+1. get_diffsky_sed_info calculates composite the composite SED and photometry of
+a population of diffsky galaxies
+
+2. decompose_sfh_into_bulge_disk_knots decomposes the composite SED into 3 components:
+bulge, diffuse disk, star-forming knots
+
 """
 from diffsky.experimental.dspspop.burstshapepop import (
     _get_burstshape_galpop_from_params,
@@ -11,7 +18,15 @@ from diffsky.experimental.dspspop.lgfburstpop import _get_lgfburst_galpop_from_u
 from diffsky.experimental.photometry_interpolation import interpolate_ssp_photmag_table
 from diffstar.defaults import SFR_MIN
 from dsps.cosmology.flat_wcdm import _age_at_z_vmap
-from dsps.experimental.diffburst import _age_weights_from_u_params
+from dsps.experimental.diffburst import (
+    _age_weights_from_u_params as _burst_age_weights_from_u_params,
+)
+from dsps.experimental.diffburst import (
+    _age_weights_from_params as _burst_age_weights_from_params,
+)
+from dsps.experimental.diffburst import (
+    _get_params_from_u_params as _get_burst_params_from_u_params,
+)
 from dsps.metallicity.mzr import DEFAULT_MZR_PDICT, mzr_model
 from dsps.sed import calc_ssp_weights_sfh_table_lognormal_mdf
 from dsps.sed.stellar_age_weights import (
@@ -23,8 +38,9 @@ from jax import numpy as jnp
 from jax import random as jran
 from jax import vmap
 
+from ..disk_bulge_modeling.disk_bulge_kernels import calc_tform_pop
 from ..disk_bulge_modeling.disk_knots import FKNOT_MAX, _disk_knot_vmap
-from ..disk_bulge_modeling.mc_disk_bulge import mc_disk_bulge
+from ..disk_bulge_modeling.mc_disk_bulge import _bulge_sfh_vmap, generate_fbulge_params
 
 _D = (None, 0, None, 0)
 calc_age_weights_from_sfh_table_vmap = jjit(
@@ -44,12 +60,20 @@ _calc_logsm_table_from_sfh_table_vmap = jjit(
 )
 
 _A = (None, 0)
-_age_weights_from_u_params_vmap = jjit(vmap(_age_weights_from_u_params, in_axes=_A))
+_burst_age_weights_from_u_params_vmap = jjit(
+    vmap(_burst_age_weights_from_u_params, in_axes=_A)
+)
+_burst_age_weights_from_params_vmap = jjit(
+    vmap(_burst_age_weights_from_params, in_axes=_A)
+)
+
+_get_burst_params_from_u_params_vmap = jjit(vmap(_get_burst_params_from_u_params))
 
 DEFAULT_MZR_PARAMS = jnp.array(list(DEFAULT_MZR_PDICT.values()))
 
 
 def get_diffsky_sed_info(
+    ran_key,
     ssp_z_table,
     ssp_rest_seds,
     ssp_restmag_table,
@@ -72,22 +96,175 @@ def get_diffsky_sed_info(
     met_params=DEFAULT_MZR_PARAMS,
     lgmet_scatter=0.2,
 ):
+    """Compute SED and photometry for population of Diffsky galaxies
+
+    Parameters
+    ----------
+    ran_key : jax.random.PRNGKey
+        Random number seed used to assign values for disk/bulge/knot decomposition
+
+    ssp_z_table : ndarray, shape (n_z_table, )
+        Table storing a grid in redshift at which SSP photometry have been precomputed
+
+    ssp_rest_seds : ndarray, shape (n_met, n_age, n_wave_seds)
+        Restframe SEDs of collection of SSPs with fluxes defined
+        in units of [Lsun/Hz/Mstar] on a grid of metallicity and age
+
+    ssp_restmag_table : ndarray, shape (n_met, n_age, n_rest_filters)
+        Restframe AB magnitude of SSPs integrated across input transmission curves
+        for n_rest_filters filters
+
+    ssp_obsmag_table : ndarray, shape (n_z_table, n_met, n_age, n_obs_filters)
+        Apparent AB magnitude of SSPs observed on a redshift grid with n_z_table points
+        for n_obs_filters filters
+
+    ssp_lgmet : ndarray, shape (n_met, )
+        Grid in metallicity Z at which the SSPs are computed, stored as log10(Z)
+
+    ssp_lg_age_gyr : ndarray, shape (n_age, )
+        Grid in age τ at which the SSPs are computed, stored as log10(τ/Gyr)
+
+    gal_t_table : ndarray, shape (n_t, )
+        Grid in cosmic time t in Gyr at which SFH of the galaxy population is tabulated
+        gal_t_table should increase monotonically and it should span the
+        full range of gal_t_obs, including some padding of a few million years
+
+    gal_z_obs : ndarray, shape (n_gals, )
+        Redshift of each galaxy
+
+    gal_sfr_table : ndarray, shape (n_gals, n_t)
+        Grid in SFR in Msun/yr for each galaxy tabulated at the input gal_t_table
+
+    cosmo_params : ndarray, shape (n_cosmo, )
+        In dsps.cosmology.flat_wcdm, cosmo_params = (Om0, w0, wa, h)
+
+    rest_filter_waves : ndarray, shape (n_rest_filters, n_trans_wave)
+        Grid in λ in angstroms at which n_rest_filters filter transmission
+        curves are defined.
+
+        Note that each observer- and rest-frame filter transmission curve must be
+        specified by a λ-grid with the same number of points.
+
+    rest_filter_trans : ndarray, shape (n_rest_filters, n_trans_wave)
+        Transmission curves of n_rest_filters for photometry restframe absolute mags
+
+    obs_filter_waves : ndarray, shape (n_obs_filters, n_trans_wave)
+        Grid in λ in angstroms at which n_obs_filters filter transmission
+        curves are defined
+
+        Note that each observer- and rest-frame filter transmission curve must be
+        specified by a λ-grid with the same number of points.
+
+    obs_filter_trans : ndarray, shape (n_obs_filters, n_trans_wave)
+        Transmission curves of n_obs_filters for photometry apparent mags
+
+    lgfburst_pop_u_params : ndarray, shape (n_pars_lgfburst_pop, )
+        Unbounded parameters controlling Fburst, which sets the fractional contribution
+        of a recent burst to the smooth SFH of a galaxy. For typical values, see
+        diffsky.experimental.dspspop.lgfburstpop.DEFAULT_LGFBURST_U_PARAMS
+
+    burstshapepop_u_params : ndarray, shape (n_pars_burstshape_pop, )
+        Unbounded parameters controlling the distribution of stellar ages
+        of stars formed in a recent burst. For typical values, see
+        diffsky.experimental.dspspop.burstshapepop.DEFAULT_BURSTSHAPE_U_PARAMS
+
+    lgav_u_params : ndarray, shape (n_pars_lgav_pop, )
+        Unbounded parameters controlling the distribution of dust parameter Av,
+        the normalization of the attenuation curve at λ_V=5500 angstrom.
+        For typical values, see
+        diffsky.experimental.dspspop.lgavpop.DEFAULT_LGAV_U_PARAMS
+
+    dust_delta_u_params : ndarray, shape (n_pars_dust_delta_pop, )
+        Unbounded parameters controlling the distribution of dust parameter δ,
+        which modifies the power-law slope of the attenuation curve. For typical values,
+        see diffsky.experimental.dspspop.dust_deltapop.DEFAULT_DUST_DELTA_U_PARAMS
+
+    fracuno_pop_u_params : ndarray, shape (n_pars_fracuno_pop, )
+        Unbounded parameters controlling the fraction of sightlines unobscured by dust.
+        For typical values, see diffsky.experimental.dspspop.boris_dust.DEFAULT_U_PARAMS
+
+    met_params : ndarray, shape (n_pars_met_pop, ), optional
+        Parameters controlling the mass-metallicity scaling relation.
+        For typical values, see dsps.metallicity.mzr.DEFAULT_MZR_PDICT
+
+    lgmet_scatter : float, optional
+        Scatter in dex of the metallicity distribution function. Default is 0.2.
+
+    Returns
+    ----------
+    gal_weights : ndarray, shape (n_gals, n_met, n_age)
+        Probability distribution P(Z, τ_age) for each galaxy
+
+    gal_frac_trans_obs : ndarray, shape (n_gals, n_age, n_obs_filters)
+        For each galaxy, array stores the fraction of light transmitted through dust
+        as a function of τ_age and filter bandpass used in observer-frame magnitudes
+
+    gal_frac_trans_rest : ndarray, shape (n_gals, n_age, n_rest_filters)
+        For each galaxy, array stores the fraction of light transmitted through dust
+        as a function of τ_age and filter bandpass used in rest-frame magnitudes
+
+    gal_att_curve_params : ndarray, shape (n_gals, 3)
+        Dust attenuation curve parameters (Eb, δ, Av) for each galaxy
+
+    gal_frac_unobs : ndarray, shape (n_gals, n_age)
+        Unobscured fraction for every galaxy at every τ_age
+
+    gal_fburst : ndarray, shape (n_gals, )
+        Fraction of the galaxy mass in the bursting population at gal_t_obs
+
+    gal_burstshape_params : ndarray, shape (n_gals, 2)
+        Parameters controlling P(τ) for burst population in each galaxy
+        lgyr_peak = gal_burstshape_params[:, 0]
+        lgyr_max = gal_burstshape_params[:, 1]
+
+    gal_fbulge_params : ndarray, shape (n_gals, 3)
+        Bulge efficiency parameters (tcrit, fbulge_early, fbulge_late) for each galaxy
+
+    gal_fknot : ndarray, shape (n_gals, )
+        Fraction of the disk mass in bursty star-forming knots for each galaxy
+
+    gal_rest_seds : ndarray, shape (n_gals, n_wave_seds)
+        Restframe SEDs of each galaxy in units of Lsun/Hz
+
+    gal_obsmags_nodust : ndarray, shape (n_gals, n_obs_filters)
+        Apparent AB magnitude of each galaxy through each filter,
+        neglecting dust attenuation
+
+    gal_restmags_nodust : ndarray, shape (n_gals, n_rest_filters)
+        Rest-frame AB magnitude of each galaxy through each filter,
+        neglecting dust attenuation
+
+    gal_obsmags_dust : ndarray, shape (n_gals, n_obs_filters)
+        Apparent AB magnitude of each galaxy through each filter,
+        accounting for dust attenuation
+
+    gal_restmags_dust : ndarray, shape (n_gals, n_rest_filters)
+        Rest-frame AB magnitude of each galaxy through each filter,
+        accounting for dust attenuation
+
+    """
+    # Bounds check input arguments and extract array shapes and sizes
     _check_ssp_info_shapes(ssp_z_table, gal_z_obs)
 
     ssp_obsmag_table_pergal = _get_ssp_obsmag_table_pergal(
         gal_z_obs, ssp_z_table, ssp_obsmag_table, ssp_restmag_table, gal_sfr_table
     )
-    ssp_obsflux_table_pergal = 10 ** (-0.4 * ssp_obsmag_table_pergal)
-    ssp_restflux_table = 10 ** (-0.4 * ssp_restmag_table)
-
     n_gals, n_met, n_age, n_obs_filters = ssp_obsmag_table_pergal.shape
     n_rest_filters = ssp_restmag_table.shape[-1]
 
-    _res = _get_galprops_at_t_obs(
+    # Compute various galaxy properties at z_obs
+    _galprops = _get_galprops_at_t_obs(
         gal_z_obs, gal_t_table, gal_sfr_table, met_params, cosmo_params
     )
-    gal_t_obs, gal_logsm_t_obs, gal_logssfr_t_obs, gal_lgmet_t_obs = _res
+    gal_t_obs, gal_logsm_t_obs, gal_logssfr_t_obs, gal_lgmet_t_obs = _galprops[:4]
+    gal_t10, gal_t90, gal_logsm0 = _galprops[4:]
 
+    # Monte Carlo generate morphology parameters
+    fbulge_key, knot_key = jran.split(ran_key, 2)
+    gal_fbulge_params = generate_fbulge_params(fbulge_key, gal_t10, gal_t90, gal_logsm0)
+    gal_fknot = jran.uniform(knot_key, minval=0, maxval=FKNOT_MAX, shape=(n_gals,))
+
+    # Compute P(Z) and P(τ) for every galaxy
     args = (
         gal_t_table,
         gal_sfr_table,
@@ -97,46 +274,62 @@ def get_diffsky_sed_info(
         ssp_lg_age_gyr,
         gal_t_obs,
     )
-    _res = calc_ssp_weights_sfh_table_lognormal_mdf_vmap(*args)
-    lgmet_weights, smooth_age_weights = _res[1:]
+    _weights = calc_ssp_weights_sfh_table_lognormal_mdf_vmap(*args)
+    lgmet_weights, smooth_age_weights = _weights[1:]
 
+    # Compute burst fraction for every galaxy
     gal_lgf_burst = _get_lgfburst_galpop_from_u_params(
         gal_logsm_t_obs, gal_logssfr_t_obs, lgfburst_pop_u_params
     )
     gal_fburst = 10**gal_lgf_burst
 
-    burstshape_u_params = _get_burstshape_galpop_from_params(
+    # Compute P(τ) for each bursting population
+    gal_u_lgyr_peak, gal_u_lgyr_max = _get_burstshape_galpop_from_params(
         gal_logsm_t_obs, gal_logssfr_t_obs, burstshapepop_u_params
     )
-    burstshape_u_params = jnp.array(burstshape_u_params).T
+    burstshape_u_params = jnp.array((gal_u_lgyr_peak, gal_u_lgyr_max)).T
     ssp_lg_age_yr = ssp_lg_age_gyr + 9
-    burst_weights = _age_weights_from_u_params_vmap(ssp_lg_age_yr, burstshape_u_params)
+    burst_age_weights = _burst_age_weights_from_u_params_vmap(
+        ssp_lg_age_yr, burstshape_u_params
+    )
 
+    gal_lgyr_peak, gal_lgyr_max = _get_burst_params_from_u_params_vmap(
+        burstshape_u_params
+    )
+    gal_burstshape_params = jnp.array((gal_lgyr_peak, gal_lgyr_max)).T
+
+    # Compute P(τ) for each composite galaxy
     _fb = gal_fburst.reshape((n_gals, 1))
-    bursty_age_weights = _fb * burst_weights + (1 - _fb) * smooth_age_weights
+    gal_age_weights = _fb * burst_age_weights + (1 - _fb) * smooth_age_weights
 
-    _w_age = bursty_age_weights.reshape((n_gals, 1, n_age))
+    # Compute P(τ, Z) for each composite galaxy
+    _w_age = gal_age_weights.reshape((n_gals, 1, n_age))
     _w_met = lgmet_weights.reshape((n_gals, n_met, 1))
     _w = _w_age * _w_met
     _norm = jnp.sum(_w, axis=(1, 2))
     gal_weights = _w / _norm.reshape((n_gals, 1, 1))  # (n_gals, n_met, n_age)
     gal_weights = gal_weights.reshape((n_gals, n_met, n_age, 1))
 
+    # Compute rest SED for each composite galaxy
+    prod_rest_seds_per_mstar = gal_weights * ssp_rest_seds
     gal_mstar_obs = (10**gal_logsm_t_obs).reshape((n_gals, 1))
+    gal_rest_seds = jnp.sum(prod_rest_seds_per_mstar, axis=(1, 2)) * gal_mstar_obs
 
-    prod_rest_seds = gal_weights * ssp_rest_seds
-    gal_rest_seds = jnp.sum(prod_rest_seds, axis=(1, 2)) * gal_mstar_obs
-
+    # Compute apparent magnitude in each band for each composite galaxy neglecting dust
+    ssp_obsflux_table_pergal = 10 ** (-0.4 * ssp_obsmag_table_pergal)
     prod_obs_nodust = gal_weights * ssp_obsflux_table_pergal
     gal_obsflux_nodust = jnp.sum(prod_obs_nodust, axis=(1, 2)) * gal_mstar_obs
     gal_obsmags_nodust = -2.5 * jnp.log10(gal_obsflux_nodust)
 
+    # Compute restframe magnitude in each band for each composite galaxy neglecting dust
+    ssp_restflux_table = 10 ** (-0.4 * ssp_restmag_table)
     prod_rest = gal_weights * ssp_restflux_table
     gal_restflux_nodust = jnp.sum(prod_rest, axis=(1, 2)) * gal_mstar_obs
     gal_restmags_nodust = -2.5 * jnp.log10(gal_restflux_nodust)
 
+    # Compute attenuation through each observed filter bandpass
     dummy_dust_key = 0
-    _res = _frac_dust_transmission_lightcone_kernel(
+    _dust_results_obs = _frac_dust_transmission_lightcone_kernel(
         dummy_dust_key,
         gal_z_obs,
         gal_logsm_t_obs,
@@ -149,15 +342,17 @@ def get_diffsky_sed_info(
         dust_delta_u_params,
         fracuno_pop_u_params,
     )
-    gal_frac_trans_obs = _res[0]  # (n_gals, n_age, n_filters)
-    gal_att_curve_params, gal_frac_unobs = _res[1:]
+    gal_frac_trans_obs = _dust_results_obs[0]  # (n_gals, n_age, n_filters)
+    gal_att_curve_params, gal_frac_unobs = _dust_results_obs[1:]
 
+    # Apply dust attenuation to the apparent magnitude in each band for each galaxy
     ft_obs = gal_frac_trans_obs.reshape((n_gals, 1, n_age, n_obs_filters))
     prod_obs_dust = gal_weights * ssp_obsflux_table_pergal * ft_obs
     gal_obsflux_dust = jnp.sum(prod_obs_dust, axis=(1, 2)) * gal_mstar_obs
     gal_obsmags_dust = -2.5 * jnp.log10(gal_obsflux_dust)
 
-    _res = _frac_dust_transmission_singlez_kernel(
+    # Compute attenuation through each restframe filter bandpass
+    _dust_results_rest = _frac_dust_transmission_singlez_kernel(
         dummy_dust_key,
         0.0,
         gal_logsm_t_obs,
@@ -170,19 +365,24 @@ def get_diffsky_sed_info(
         dust_delta_u_params,
         fracuno_pop_u_params,
     )
-    gal_frac_trans_rest = _res[0]  # (n_gals, n_age, n_filters)
+    gal_frac_trans_rest = _dust_results_rest[0]  # (n_gals, n_age, n_filters)
 
+    # Apply dust attenuation to the restframe magnitude in each band for each galaxy
     ft_rest = gal_frac_trans_rest.reshape((n_gals, 1, n_age, n_rest_filters))
     prod_rest_dust = gal_weights * ssp_restflux_table * ft_rest
     gal_restflux_dust = jnp.sum(prod_rest_dust, axis=(1, 2)) * gal_mstar_obs
     gal_restmags_dust = -2.5 * jnp.log10(gal_restflux_dust)
 
     return (
-        gal_weights,
+        gal_weights.reshape((n_gals, n_met, n_age)),
         gal_frac_trans_obs,
         gal_frac_trans_rest,
         gal_att_curve_params,
         gal_frac_unobs,
+        gal_fburst,
+        gal_burstshape_params,
+        gal_fbulge_params,
+        gal_fknot,
         gal_rest_seds,
         gal_obsmags_nodust,
         gal_restmags_nodust,
@@ -191,16 +391,111 @@ def get_diffsky_sed_info(
     )
 
 
-def decompose_sfh_into_bulge_disk_knots(
-    ran_key, gal_t_obs, gal_t_table, gal_sfh, fburst, age_weights_burst, ssp_lg_age_gyr
+def decompose_sfhpop_into_bulge_disk_knots(
+    gal_fbulge_params,
+    gal_fknot,
+    gal_t_obs,
+    gal_t_table,
+    gal_sfh,
+    gal_fburst,
+    gal_burstshape_params,
+    ssp_lg_age_gyr,
 ):
-    bulge_key, knot_key = jran.split(ran_key, 2)
+    """Decompose the SFH of a Diffsky galaxy into three components:
+    bulges, diffuse disk, and star-forming knots in the disks
 
-    gal_smh, eff_bulge, bulge_sfh, bulge_smh, bth = mc_disk_bulge(
-        bulge_key, gal_t_table, gal_sfh
+    Parameters
+    ----------
+    gal_fbulge_params : ndarray, shape (n_gals, 3)
+        Bulge efficiency parameters (tcrit, fbulge_early, fbulge_late) for each galaxy
+
+    gal_fknot : ndarray, shape (n_gals, )
+        Fraction of the disk mass in bursty star-forming knots for each galaxy
+
+    gal_t_obs : ndarray, shape (n_gals, )
+        Age of the universe in Gyr at the redshift of each galaxy
+
+    gal_t_table : ndarray, shape (n_t, )
+        Grid in cosmic time t in Gyr at which SFH of the galaxy population is tabulated
+        gal_t_table should increase monotonically and it should span the
+        full range of gal_t_obs, including some padding of a few million years
+
+    gal_sfh : ndarray, shape (n_gals, n_t)
+        Grid in SFR in Msun/yr for each galaxy tabulated at the input gal_t_table
+
+    gal_fburst : ndarray, shape (n_gals, )
+        Fraction of stellar mass in the burst population of each galaxy
+
+    gal_burstshape_params : ndarray, shape (n_gals, 2)
+        Parameters controlling P(τ) for burst population in each galaxy
+        lgyr_peak = gal_burstshape_params[:, 0]
+        lgyr_max = gal_burstshape_params[:, 1]
+
+    ssp_lg_age_gyr : ndarray, shape (n_age, )
+        Grid in age τ at which the SSPs are computed, stored as log10(τ/Gyr)
+
+    Returns
+    -------
+    mbulge : ndarray, shape (n_gals, )
+        Total stellar mass in Msun formed in the bulge at time gal_t_obs
+
+    mdd : ndarray, shape (n_gals, )
+        Total stellar mass in Msun formed in the diffuse disk at time gal_t_obs
+
+    mknot : ndarray, shape (n_gals, )
+        Total stellar mass in Msun formed in star-forming knots at time gal_t_obs
+
+    mburst : ndarray, shape (n_gals, )
+        Total stellar mass in Msun in the burst population at time gal_t_obs
+
+    bulge_age_weights : ndarray, shape (n_gals, n_age)
+        Probability distribution P(τ_age) for bulge of each galaxy
+
+    dd_age_weights : ndarray, shape (n_gals, n_age)
+        Probability distribution P(τ_age) for diffuse disk of each galaxy
+
+    knot_age_weights : ndarray, shape (n_gals, n_age)
+        Probability distribution P(τ_age) for star-forming knots of each galaxy
+
+    bulge_sfh : ndarray, shape (n_gals, n_t)
+        Grid in SFR in Msun/yr for each galaxy bulge tabulated at the input gal_t_table
+
+    frac_bulge_t_obs : ndarray, shape (n_gals, )
+        Bulge/total mass ratio at gal_t_obs for every galaxy
+
+    """
+    ssp_lg_age_yr = ssp_lg_age_gyr + 9.0
+    gal_burst_age_weights = _burst_age_weights_from_params_vmap(
+        ssp_lg_age_yr, gal_burstshape_params
     )
+    return _decompose_sfhpop_into_bulge_disk_knots(
+        gal_fbulge_params,
+        gal_fknot,
+        gal_t_obs,
+        gal_t_table,
+        gal_sfh,
+        gal_fburst,
+        gal_burst_age_weights,
+        ssp_lg_age_gyr,
+    )
+
+
+@jjit
+def _decompose_sfhpop_into_bulge_disk_knots(
+    gal_fbulge_params,
+    gal_fknot,
+    gal_t_obs,
+    gal_t_table,
+    gal_sfh,
+    gal_fburst,
+    age_weights_burst,
+    ssp_lg_age_gyr,
+):
+    _res = _bulge_sfh_vmap(gal_t_table, gal_sfh, gal_fbulge_params)
+    smh, eff_bulge, bulge_sfh, smh_bulge, bulge_to_total_history = _res
+
     bulge_sfh = jnp.where(bulge_sfh < SFR_MIN, SFR_MIN, bulge_sfh)
-    frac_bulge_t_obs = _linterp_vmap(gal_t_obs, gal_t_table, bth)
+    frac_bulge_t_obs = _linterp_vmap(gal_t_obs, gal_t_table, bulge_to_total_history)
 
     bulge_age_weights = calc_age_weights_from_sfh_table_vmap(
         gal_t_table, bulge_sfh, ssp_lg_age_gyr, gal_t_obs
@@ -209,26 +504,23 @@ def decompose_sfh_into_bulge_disk_knots(
     disk_sfh = gal_sfh - bulge_sfh
     disk_sfh = jnp.where(disk_sfh < SFR_MIN, SFR_MIN, disk_sfh)
 
-    n_gals = gal_sfh.shape[0]
-    fknot = jran.uniform(knot_key, minval=0, maxval=FKNOT_MAX, shape=(n_gals,))
-
     args = (
         gal_t_table,
         gal_t_obs,
         gal_sfh,
         disk_sfh,
-        fburst,
-        fknot,
+        gal_fburst,
+        gal_fknot,
         age_weights_burst,
         ssp_lg_age_gyr,
     )
-    _res = _disk_knot_vmap(*args)
-    mstar_tot, mburst, mdd, mknot, dd_age_weights, knot_age_weights = _res
+    _knot_info = _disk_knot_vmap(*args)
+    mstar_tot, mburst, mdd, mknot, dd_age_weights, knot_age_weights = _knot_info
 
     mbulge = frac_bulge_t_obs * mstar_tot
     masses = mbulge, mdd, mknot, mburst
     age_weights = bulge_age_weights, dd_age_weights, knot_age_weights
-    ret = (*masses, *age_weights)
+    ret = (*masses, *age_weights, bulge_sfh, frac_bulge_t_obs)
     return ret
 
 
@@ -249,9 +541,22 @@ def _get_galprops_at_t_obs(
     gal_logsfr_t_obs = _linterp_vmap(lgt_obs, lgt_table, gal_logsfr_table)
     gal_logssfr_t_obs = gal_logsfr_t_obs - gal_logsm_t_obs
 
+    gal_smh_table = 10**gal_logsm_table
+    gal_t10 = calc_tform_pop(gal_t_table, gal_smh_table, 0.1)
+    gal_t90 = calc_tform_pop(gal_t_table, gal_smh_table, 0.9)
+    gal_logsm0 = gal_smh_table[:, -1]
+
     gal_lgmet_t_obs = mzr_model(gal_logsm_t_obs, gal_t_obs, *met_params[:-1])
 
-    return gal_t_obs, gal_logsm_t_obs, gal_logssfr_t_obs, gal_lgmet_t_obs
+    return (
+        gal_t_obs,
+        gal_logsm_t_obs,
+        gal_logssfr_t_obs,
+        gal_lgmet_t_obs,
+        gal_t10,
+        gal_t90,
+        gal_logsm0,
+    )
 
 
 def _check_ssp_info_shapes(ssp_z_table, gal_z_obs):
@@ -291,5 +596,9 @@ def _get_ssp_obsmag_table_pergal(
 
     msg = "ssp_obsmag_table.shape[2]={0} must equal ssp_restmag_table.shape[1]={1}"
     assert n_age == n_age2, msg.format(n_age, n_age2)
+
+    return ssp_obsmag_table_pergal
+
+    return ssp_obsmag_table_pergal
 
     return ssp_obsmag_table_pergal

--- a/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp.py
+++ b/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp.py
@@ -10,20 +10,29 @@ from diffsky.experimental.dspspop.lgavpop import DEFAULT_LGAV_U_PARAMS
 from diffsky.experimental.dspspop.lgfburstpop import DEFAULT_LGFBURST_U_PARAMS
 from diffstar.fitting_helpers.stars import _integrate_sfr
 from dsps.experimental.diffburst import DEFAULT_PARAMS as DEFAULT_BURST_PARAMS
-from dsps.experimental.diffburst import _age_weights_from_params
+from dsps.experimental.diffburst import (
+    DLGAGE_MIN,
+    LGAGE_MAX,
+    LGYR_PEAK_MIN,
+    _age_weights_from_params,
+)
 from dsps.utils import _jax_get_dt_array
 from jax import jit as jjit
 from jax import random as jran
 from jax import vmap
 
-_B = (0, None)
-_integrate_sfr_vmap = jjit(vmap(_integrate_sfr, in_axes=_B))
-
+from ...disk_bulge_modeling.disk_knots import FKNOT_MAX
+from ...disk_bulge_modeling.mc_disk_bulge import mc_disk_bulge
 from ..photometry_lc_interp import (
+    _burst_age_weights_from_params_vmap,
+    _decompose_sfhpop_into_bulge_disk_knots,
     _linterp_vmap,
-    decompose_sfh_into_bulge_disk_knots,
+    decompose_sfhpop_into_bulge_disk_knots,
     get_diffsky_sed_info,
 )
+
+_B = (0, None)
+_integrate_sfr_vmap = jjit(vmap(_integrate_sfr, in_axes=_B))
 
 
 def test_get_diffsky_sed_info():
@@ -63,7 +72,9 @@ def test_get_diffsky_sed_info():
     ssp_restmag_table = np.random.uniform(size=(n_met, n_age, n_rest_filters))
     ssp_obsmag_table = np.random.uniform(size=(n_z_table, n_met, n_age, n_obs_filters))
 
+    ran_key = jran.PRNGKey(0)
     _res = get_diffsky_sed_info(
+        ran_key,
         ssp_z_table,
         ssp_rest_seds,
         ssp_restmag_table,
@@ -93,17 +104,36 @@ def test_get_diffsky_sed_info():
         gal_frac_trans_rest,
         gal_att_curve_params,
         gal_frac_unobs,
+        gal_fburst,
+        gal_burstshape_params,
+        gal_fbulge_params,
+        gal_fknot,
         gal_rest_seds,
         gal_obsmags_nodust,
         gal_restmags_nodust,
         gal_obsmags_dust,
         gal_restmags_dust,
     ) = _res
-    assert weights.shape == (n_gals, n_met, n_age, 1)
+    assert weights.shape == (n_gals, n_met, n_age)
     assert gal_frac_trans_obs.shape == (n_gals, n_age, n_obs_filters)
     assert gal_frac_trans_rest.shape == (n_gals, n_age, n_rest_filters)
     assert gal_att_curve_params.shape == (n_gals, 3)
     assert gal_frac_unobs.shape == (n_gals, n_age)
+
+    assert gal_fburst.shape == (n_gals,)
+    assert gal_burstshape_params.shape == (n_gals, 2)
+    assert np.all(gal_fburst > 0)
+    assert np.all(gal_fburst < 0.1)
+    lgyr_peak = gal_burstshape_params[:, 0]
+    lgyr_max = gal_burstshape_params[:, 1]
+    assert np.all(lgyr_peak > LGYR_PEAK_MIN)
+    assert np.all(lgyr_max > lgyr_peak + DLGAGE_MIN)
+    assert np.all(lgyr_max < LGAGE_MAX)
+
+    assert gal_fbulge_params.shape == (n_gals, 3)
+    assert gal_fknot.shape == (n_gals,)
+    assert np.all(gal_fknot > 0)
+    assert np.all(gal_fknot < FKNOT_MAX)
 
     assert gal_rest_seds.shape == (n_gals, n_wave_seds)
 
@@ -120,6 +150,11 @@ def test_get_diffsky_sed_info():
 
 
 def test_decompose_sfh_into_bulge_disk_knots():
+    """Enforce physically reasonable disk/bulge/knot decomposition for some random
+    galaxy distributions. Run n_tests tests for galaxy populations with
+    different distributions of {Fburst, t_obs}
+
+    """
     ran_key = jran.PRNGKey(0)
 
     n_age = 40
@@ -127,43 +162,140 @@ def test_decompose_sfh_into_bulge_disk_knots():
     ssp_lg_age_gyr = ssp_lg_age_yr - 9.0
 
     n_t = 100
-    tmin, tmax = 0.1, 13.8
-    gal_t_table = np.linspace(tmin, tmax, n_t)
+    t0 = 13.8
+    t_table_min = 0.01
+    gal_t_table = np.linspace(t_table_min, t0, n_t)
 
-    n_gals = 150
+    n_gals = 1_000
+    n_tests = 20
+    for itest in range(n_tests):
+        itest_key, ran_key = jran.split(ran_key, 2)
 
-    gal_t_obs = np.random.uniform(tmin, tmax, n_gals)
-    gal_sfh = np.random.uniform(0, 100, n_gals * n_t).reshape((n_gals, n_t))
-    fburst = 10 ** np.random.uniform(-4, -2, n_gals)
+        # make sure t_obs > t_table_min
+        t_obs_min = 0.2
+        gal_t_obs = np.random.uniform(t_obs_min, t0 - 0.05, n_gals)
+        sfh_peak_max = np.random.uniform(0, 200)
+        sfh_peak = np.random.uniform(0, sfh_peak_max, n_gals)
+        gal_sfh_u = np.random.uniform(0, 1, n_gals * n_t).reshape((n_gals, n_t))
+        gal_sfh = gal_sfh_u * sfh_peak.reshape((n_gals, 1))
 
-    age_weights_singleburst = _age_weights_from_params(
-        ssp_lg_age_yr, DEFAULT_BURST_PARAMS
-    )
-    age_weights_burstpop = np.tile(age_weights_singleburst, n_gals)
-    age_weights_burstpop = age_weights_burstpop.reshape((n_gals, n_age))
+        LGFBURST_UPPER_BOUND = -1
+        lgfb_max = np.random.uniform(-3, LGFBURST_UPPER_BOUND)
+        lgfb_min = np.random.uniform(lgfb_max - 3, lgfb_max)
+        gal_fburst = 10 ** np.random.uniform(lgfb_min, lgfb_max, n_gals)
 
-    args = (
-        ran_key,
-        gal_t_obs,
-        gal_t_table,
-        gal_sfh,
-        fburst,
-        age_weights_burstpop,
-        ssp_lg_age_gyr,
-    )
-    _res = decompose_sfh_into_bulge_disk_knots(*args)
+        gal_burstshape_params = np.tile(DEFAULT_BURST_PARAMS, n_gals)
+        gal_burstshape_params = gal_burstshape_params.reshape((n_gals, 2))
 
-    mbulge, mdd, mknot, mburst = _res[:4]
-    bulge_age_weights, dd_age_weights, knot_age_weights = _res[4:]
+        gal_burst_age_weights = _burst_age_weights_from_params_vmap(
+            ssp_lg_age_yr, gal_burstshape_params
+        )
 
-    mtot = mbulge + mdd + mknot
-    lgmtot = np.log10(mtot)
+        age_weights_singleburst = _age_weights_from_params(
+            ssp_lg_age_yr, DEFAULT_BURST_PARAMS
+        )
+        age_weights_burstpop = np.tile(age_weights_singleburst, n_gals)
+        age_weights_burstpop = age_weights_burstpop.reshape((n_gals, n_age))
+        assert np.allclose(gal_burst_age_weights, age_weights_burstpop, rtol=0.001)
 
-    dt_table = _jax_get_dt_array(gal_t_table)
-    gal_smh = np.cumsum(gal_sfh * dt_table, axis=1) * 1e9
-    gal_logsmh = np.log10(gal_smh)
+        gal_fknot = np.random.uniform(0, FKNOT_MAX, n_gals)
+        gal_fbulge_params = mc_disk_bulge(itest_key, gal_t_table, gal_sfh)[0]
 
-    lgt_table = np.log10(gal_t_table)
-    lgmstar_t_obs = _linterp_vmap(np.log10(gal_t_obs), lgt_table, gal_logsmh)
+        args = (
+            gal_fbulge_params,
+            gal_fknot,
+            gal_t_obs,
+            gal_t_table,
+            gal_sfh,
+            gal_fburst,
+            age_weights_burstpop,
+            ssp_lg_age_gyr,
+        )
+        _res = _decompose_sfhpop_into_bulge_disk_knots(*args)
+        _res2 = decompose_sfhpop_into_bulge_disk_knots(
+            gal_fbulge_params,
+            gal_fknot,
+            gal_t_obs,
+            gal_t_table,
+            gal_sfh,
+            gal_fburst,
+            gal_burstshape_params,
+            ssp_lg_age_gyr,
+        )
+        # Enforce no NaN and that the convenience function agrees with the kernel
+        for x, x2 in zip(_res, _res2):
+            assert np.all(np.isfinite(x))
+            assert np.allclose(x, x2, rtol=1e-4)
 
-    assert np.allclose(lgmstar_t_obs, lgmtot, atol=0.01)
+        mbulge, mdd, mknot, mburst = _res[:4]
+        bulge_age_weights, dd_age_weights, knot_age_weights = _res[4:7]
+        bulge_sfh, frac_bulge_t_obs = _res[7:]
+
+        assert mbulge.shape == (n_gals,)
+        assert mdd.shape == (n_gals,)
+        assert mknot.shape == (n_gals,)
+        assert mburst.shape == (n_gals,)
+        assert bulge_age_weights.shape == (n_gals, n_age)
+        assert dd_age_weights.shape == (n_gals, n_age)
+        assert knot_age_weights.shape == (n_gals, n_age)
+        assert bulge_sfh.shape == (n_gals, n_t)
+        assert frac_bulge_t_obs.shape == (n_gals,)
+
+        # Each galaxy's age weights should be a unit-normalized PDF
+        assert np.allclose(np.sum(bulge_age_weights, axis=1), 1.0, rtol=0.01)
+        assert np.allclose(np.sum(dd_age_weights, axis=1), 1.0, rtol=0.01)
+        assert np.allclose(np.sum(knot_age_weights, axis=1), 1.0, rtol=0.01)
+
+        # The sum of the masses in each component should equal
+        # # the total stellar mass formed at gal_t_obs
+        mtot = mbulge + mdd + mknot
+        lgmtot = np.log10(mtot)
+
+        dt_table = _jax_get_dt_array(gal_t_table)
+        gal_smh = np.cumsum(gal_sfh * dt_table, axis=1) * 1e9
+        gal_logsmh = np.log10(gal_smh)
+
+        lgt_table = np.log10(gal_t_table)
+        lgmstar_t_obs = _linterp_vmap(np.log10(gal_t_obs), lgt_table, gal_logsmh)
+
+        assert np.allclose(lgmstar_t_obs, lgmtot, atol=0.01)
+
+        # Star-forming knots should never have fewer young stars than the diffuse disk
+        dd_age_cdf = np.cumsum(dd_age_weights, axis=1)
+        knot_age_cdf = np.cumsum(knot_age_weights, axis=1)
+
+        tol = 0.01
+        indx_ostar = np.searchsorted(ssp_lg_age_yr, 6.5)
+        assert np.all(dd_age_cdf[:, indx_ostar] <= knot_age_cdf[:, indx_ostar] + tol)
+        assert np.any(dd_age_cdf[:, indx_ostar] < knot_age_cdf[:, indx_ostar])
+
+        # The bulge should never have more young stars than star-forming knots
+        tol = 0.01
+        bulge_age_cdf = np.cumsum(bulge_age_weights, axis=1)
+        assert np.all(bulge_age_cdf[:, indx_ostar] <= knot_age_cdf[:, indx_ostar] + tol)
+
+        # On average, star-forming knots should be younger than diffuse disks
+        # and diffuse disks should should be younger than bulges
+        bulge_median_frac_ob_stars = np.median(bulge_age_cdf[:, indx_ostar])
+        dd_median_frac_ob_stars = np.median(dd_age_cdf[:, indx_ostar])
+        knot_median_frac_ob_stars = np.median(knot_age_cdf[:, indx_ostar])
+        assert (
+            bulge_median_frac_ob_stars
+            < dd_median_frac_ob_stars
+            < knot_median_frac_ob_stars
+        )
+
+        # Bulge SFH should never exceed total SFH
+        assert np.all(bulge_sfh <= gal_sfh)
+
+        # Bulge SFH should fall below total SFH at some point in history of each galaxy
+        assert np.all(np.any(bulge_sfh < gal_sfh, axis=1))
+
+        # Bulge fraction should respect 0 < frac_bulge < 1 for every galaxy
+        assert np.all(frac_bulge_t_obs > 0)
+        assert np.all(frac_bulge_t_obs < 1)
+        # Bulge fraction should respect 0 < frac_bulge < 1 for every galaxy
+        assert np.all(frac_bulge_t_obs > 0)
+        assert np.all(frac_bulge_t_obs < 1)
+        assert np.all(frac_bulge_t_obs < 1)
+        assert np.all(frac_bulge_t_obs < 1)

--- a/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp.py
+++ b/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp.py
@@ -8,8 +8,22 @@ from diffsky.experimental.dspspop.burstshapepop import DEFAULT_BURSTSHAPE_U_PARA
 from diffsky.experimental.dspspop.dust_deltapop import DEFAULT_DUST_DELTA_U_PARAMS
 from diffsky.experimental.dspspop.lgavpop import DEFAULT_LGAV_U_PARAMS
 from diffsky.experimental.dspspop.lgfburstpop import DEFAULT_LGFBURST_U_PARAMS
+from diffstar.fitting_helpers.stars import _integrate_sfr
+from dsps.experimental.diffburst import DEFAULT_PARAMS as DEFAULT_BURST_PARAMS
+from dsps.experimental.diffburst import _age_weights_from_params
+from dsps.utils import _jax_get_dt_array
+from jax import jit as jjit
+from jax import random as jran
+from jax import vmap
 
-from ..photometry_lc_interp import get_diffsky_sed_info
+_B = (0, None)
+_integrate_sfr_vmap = jjit(vmap(_integrate_sfr, in_axes=_B))
+
+from ..photometry_lc_interp import (
+    _linterp_vmap,
+    decompose_sfh_into_bulge_disk_knots,
+    get_diffsky_sed_info,
+)
 
 
 def test_get_diffsky_sed_info():
@@ -103,3 +117,53 @@ def test_get_diffsky_sed_info():
 
     assert np.all(gal_restmags_dust >= gal_restmags_nodust)
     assert np.any(gal_restmags_dust > gal_restmags_nodust)
+
+
+def test_decompose_sfh_into_bulge_disk_knots():
+    ran_key = jran.PRNGKey(0)
+
+    n_age = 40
+    ssp_lg_age_yr = np.linspace(5, 10.25, n_age)
+    ssp_lg_age_gyr = ssp_lg_age_yr - 9.0
+
+    n_t = 100
+    tmin, tmax = 0.1, 13.8
+    gal_t_table = np.linspace(tmin, tmax, n_t)
+
+    n_gals = 150
+
+    gal_t_obs = np.random.uniform(tmin, tmax, n_gals)
+    gal_sfh = np.random.uniform(0, 100, n_gals * n_t).reshape((n_gals, n_t))
+    fburst = 10 ** np.random.uniform(-4, -2, n_gals)
+
+    age_weights_singleburst = _age_weights_from_params(
+        ssp_lg_age_yr, DEFAULT_BURST_PARAMS
+    )
+    age_weights_burstpop = np.tile(age_weights_singleburst, n_gals)
+    age_weights_burstpop = age_weights_burstpop.reshape((n_gals, n_age))
+
+    args = (
+        ran_key,
+        gal_t_obs,
+        gal_t_table,
+        gal_sfh,
+        fburst,
+        age_weights_burstpop,
+        ssp_lg_age_gyr,
+    )
+    _res = decompose_sfh_into_bulge_disk_knots(*args)
+
+    mbulge, mdd, mknot, mburst = _res[:4]
+    bulge_age_weights, dd_age_weights, knot_age_weights = _res[4:]
+
+    mtot = mbulge + mdd + mknot
+    lgmtot = np.log10(mtot)
+
+    dt_table = _jax_get_dt_array(gal_t_table)
+    gal_smh = np.cumsum(gal_sfh * dt_table, axis=1) * 1e9
+    gal_logsmh = np.log10(gal_smh)
+
+    lgt_table = np.log10(gal_t_table)
+    lgmstar_t_obs = _linterp_vmap(np.log10(gal_t_obs), lgt_table, gal_logsmh)
+
+    assert np.allclose(lgmstar_t_obs, lgmtot, atol=0.01)


### PR DESCRIPTION
This PR brings in JAX kernels that use the latest models of dust and burstiness together with the morphology decomposition to provide separate SEDs for the disk, bulge, and star-forming knots.