### PR TITLE
New semi-weekly cron to test against diff+ main branches

### DIFF
--- a/.github/workflows/tests_cron.yml
+++ b/.github/workflows/tests_cron.yml
@@ -1,6 +1,10 @@
-name: tests
+name: test_main_branch_dependencies
 
 on:
+  workflow_dispatch: null
+  schedule:
+    # Runs "every Monday & Thursday at 3:05am Central"
+    - cron: '5 8 * * 1,4'
   push:
     branches:
       - main
@@ -27,7 +31,7 @@ jobs:
           use-mamba: true
 
       - name: configure conda and install code
-      # Test against latest releases of all diff+ dependencies
+          # Test against current main branch of all diff+ dependencies
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
@@ -43,6 +47,14 @@ jobs:
             setuptools \
             "setuptools_scm>=7,<8" \
             python-build
+          pip uninstall diffmah --yes
+          pip uninstall diffstar --yes
+          pip uninstall dsps --yes
+          pip uninstall diffsky --yes
+          pip install --no-deps git+https://github.com/ArgonneCPAC/diffmah.git
+          pip install --no-deps git+https://github.com/ArgonneCPAC/diffstar.git
+          pip install --no-deps git+https://github.com/ArgonneCPAC/dsps.git
+          pip install --no-deps git+https://github.com/ArgonneCPAC/diffsky.git
           python -m pip install --no-build-isolation --no-deps -e .
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ lsstdesc-galsampler
 psutil
 diffmah
 diffstar
+dsps
+diffsky


### PR DESCRIPTION
With every PR, we now have two separate workflows that run our test suite in different environment configurations:

1. Using the latest releases of all the Diff+ codes in our dependency chain
2. Using the current main branch of all the Diff+ codes in our dependency chain

In addition to tests triggered by a PR, tests with environment config (2) are now part of a cron job that runs this workflow twice a week (early in the morning every Monday and Thursday). This new cron should help make sure we notice when changes to the main branch of one of the Diff+ codes has downstream consequences for this repo.