### PR TITLE
Improve diversity of bulge-to-total ratio

### DIFF
--- a/lsstdesc_diffsky/disk_bulge_modeling/mc_disk_bulge.py
+++ b/lsstdesc_diffsky/disk_bulge_modeling/mc_disk_bulge.py
@@ -73,14 +73,16 @@ def generate_fbulge_params(
     logsm0,
     mu_u_tcrit=2,
     delta_mu_u_tcrit=3,
-    mu_u_early=20,
+    mu_u_early=5,
     delta_mu_u_early=0.1,
-    mu_u_late=20,
+    mu_u_late=5,
     delta_mu_u_late=3,
+    scale_u_early=10,
+    scale_u_late=8,
+    scale_u_tcrit=20,
 ):
     n = t10.size
     tcrit_key, early_key, late_key = jran.split(ran_key, 3)
-    scale_u_tcrit = 10
     u_tcrit_table = [
         mu_u_tcrit - delta_mu_u_tcrit * scale_u_tcrit,
         mu_u_tcrit + delta_mu_u_tcrit * scale_u_tcrit,
@@ -89,7 +91,6 @@ def generate_fbulge_params(
     mu_u_tcrit_pop = np.interp(logsm0, logsm_table, u_tcrit_table)
     mc_u_tcrit = jran.normal(tcrit_key, shape=(n,)) * scale_u_tcrit + mu_u_tcrit_pop
 
-    scale_u_early = 5
     u_early_table = [
         mu_u_early - delta_mu_u_early * scale_u_early,
         mu_u_early + delta_mu_u_early * scale_u_early,
@@ -97,7 +98,6 @@ def generate_fbulge_params(
     mu_u_early_pop = np.interp(logsm0, logsm_table, u_early_table)
     mc_u_early = jran.normal(early_key, shape=(n,)) * scale_u_early + mu_u_early_pop
 
-    scale_u_late = 8
     u_late_table = [
         mu_u_late + delta_mu_u_late * scale_u_late,
         mu_u_late - delta_mu_u_late * scale_u_late,


### PR DESCRIPTION
This PR updates the model parameters used to decompose the SFH of a galaxy into disk/bulge/knot components. The upshot is that there is now a much greater diversity in B/T, and the model retains its predictions for a galaxy's disk SED to generally be redder than its knot SED, and for its bulge SED to be redder than its disk.

In this first figure, B/T is the ratio of the stellar mass of the bulge to the total stellar mass. In the old model there was not much diversity in morphology: nearly all z<1 galaxies were bulge-dominated with a bit of scatter about B/T=0.85. In the new model, there is a much larger range of B/T: for example, ~30% of galaxies are disk-dominated with B/T<0.5 (whereas previously this was ~0%).
![bt_vs_logsm_diffsky](https://github.com/LSSTDESC/lsstdesc-diffsky/assets/6951595/7425438b-0d76-4357-8e46-8fe4d69ac9d8)

The next few figures plot `δ_color` on the y-axis, computed as the difference in broadband color between one galaxy component and another. So when the y-axis is positive, the first component is redder than the second. The combination of the figures below gives assurance that the new model retains the same feature as the old: bulges are redder than disks are redder than knots, which is visible across a wide range in wavelength spanning at least u-y.
![delta_gr_vs_logsm_diffsky_bulge_vs_dd](https://github.com/LSSTDESC/lsstdesc-diffsky/assets/6951595/e0df4ce1-896c-4b00-a26f-856dbce2bd20)
![delta_gr_vs_logsm_diffsky_knot_vs_dd](https://github.com/LSSTDESC/lsstdesc-diffsky/assets/6951595/9d337e0f-f13d-4567-bdc2-56c09a342d9f)
![delta_iz_vs_logsm_diffsky_knot_vs_dd](https://github.com/LSSTDESC/lsstdesc-diffsky/assets/6951595/15d434d0-abf4-48fa-acb5-9157577566f2)
![delta_ug_vs_logsm_diffsky_knot_vs_dd](https://github.com/LSSTDESC/lsstdesc-diffsky/assets/6951595/6c736180-ac04-4748-901f-408041bb3cb6)
![delta_zy_vs_logsm_diffsky_bulge_vs_dd](https://github.com/LSSTDESC/lsstdesc-diffsky/assets/6951595/bd52d037-5c09-4759-a9b3-b3216f2a5c2a)

