### PR TITLE
Add `infer_software_versions` function and incorporate into `write_mock_to_disk`

### DIFF
--- a/lsstdesc_diffsky/infer_diffcode_versions.py
+++ b/lsstdesc_diffsky/infer_diffcode_versions.py
@@ -1,0 +1,19 @@
+"""
+"""
+
+
+def infer_software_versions():
+    versions = dict()
+
+    import diffmah
+    import diffsky
+    import diffstar
+    import dsps
+    import lsstdesc_diffsky
+
+    versions["diffmah"] = diffmah.__version__
+    versions["diffsky"] = diffsky.__version__
+    versions["diffstar"] = diffstar.__version__
+    versions["dsps"] = dsps.__version__
+    versions["lsstdesc_diffsky"] = lsstdesc_diffsky.__version__
+    return versions

--- a/lsstdesc_diffsky/tests/test_infer_diffcode_versions.py
+++ b/lsstdesc_diffsky/tests/test_infer_diffcode_versions.py
@@ -1,0 +1,10 @@
+"""
+"""
+from ..infer_diffcode_versions import infer_software_versions
+
+
+def test_infer_diffcode_versions():
+    versions = infer_software_versions()
+    assert set(list(versions.keys())) == set(
+        ("diffmah", "diffstar", "dsps", "diffsky", "lsstdesc_diffsky")
+    )


### PR DESCRIPTION
@evevkovacs could you finish this PR by modifying `write_mock_to_disk` in such a way that uses the new `infer_software_versions` function? This way the different versions of the Diff+ software are inferred dynamically at runtime. So writing these versions to disk as metadata will be a bit more robust than having to make sure to manually record the correct commit hash.

Note that in order for to this to pass, you will need to have the most recent release of Diffstar installed, [v0.2.2](https://github.com/ArgonneCPAC/diffstar/releases/tag/v0.2.2), which was only released 2 days ago.