### PR TITLE
Fix bug in call to diffsky.experimental.dspspop.burstshapepop

### DIFF
--- a/lsstdesc_diffsky/photometry/photometry_lc_interp.py
+++ b/lsstdesc_diffsky/photometry/photometry_lc_interp.py
@@ -10,7 +10,7 @@ bulge, diffuse disk, star-forming knots
 import typing
 
 from diffsky.experimental.dspspop.burstshapepop import (
-    _get_burstshape_galpop_from_u_params,
+    _get_burstshape_galpop_from_params,
 )
 from diffsky.experimental.dspspop.dustpop import (
     _frac_dust_transmission_lightcone_kernel,
@@ -300,7 +300,7 @@ def get_diffsky_sed_info(
     gal_fburst = 10**gal_lgf_burst
 
     # Compute P(τ) for each bursting population
-    gal_u_lgyr_peak, gal_u_lgyr_max = _get_burstshape_galpop_from_u_params(
+    gal_u_lgyr_peak, gal_u_lgyr_max = _get_burstshape_galpop_from_params(
         gal_logsm_t_obs, gal_logssfr_t_obs, burstshapepop_u_params
     )
     burstshape_u_params = jnp.array((gal_u_lgyr_peak, gal_u_lgyr_max)).T

--- a/lsstdesc_diffsky/sed/disk_bulge_sed_kernels.py
+++ b/lsstdesc_diffsky/sed/disk_bulge_sed_kernels.py
@@ -4,7 +4,7 @@ import typing
 
 from diffsky.experimental.dspspop.boris_dust import _get_funo_from_u_params_singlegal
 from diffsky.experimental.dspspop.burstshapepop import (
-    _get_burstshape_galpop_from_u_params,
+    _get_burstshape_galpop_from_params,
 )
 from diffsky.experimental.dspspop.dust_deltapop import (
     _get_dust_delta_galpop_from_u_params,
@@ -110,7 +110,7 @@ def calc_rest_sed_disk_bulge_knot_singlegal(
     )
     fburst = 10**lgfburst
 
-    diffburst_u_params = _get_burstshape_galpop_from_u_params(
+    diffburst_u_params = _get_burstshape_galpop_from_params(
         logsm_t_obs, logssfr_t_obs, burstshapepop_u_params
     )
     burstshape_params = jnp.array(

--- a/lsstdesc_diffsky/sed/sed_kernels.py
+++ b/lsstdesc_diffsky/sed/sed_kernels.py
@@ -2,7 +2,7 @@
 """
 from diffsky.experimental.dspspop.boris_dust import _get_funo_from_u_params_singlegal
 from diffsky.experimental.dspspop.burstshapepop import (
-    _get_burstshape_galpop_from_u_params,
+    _get_burstshape_galpop_from_params,
 )
 from diffsky.experimental.dspspop.dust_deltapop import (
     _get_dust_delta_galpop_from_u_params,
@@ -168,7 +168,7 @@ def calc_rest_sed_singlegal(
     fburst = 10**lgfburst
 
     # Compute P(τ) for each bursting population
-    gal_u_lgyr_peak, gal_u_lgyr_max = _get_burstshape_galpop_from_u_params(
+    gal_u_lgyr_peak, gal_u_lgyr_max = _get_burstshape_galpop_from_params(
         logsm_t_obs, logssfr_t_obs, burstshapepop_u_params
     )
     burstshape_u_params = jnp.array((gal_u_lgyr_peak, gal_u_lgyr_max)).T


### PR DESCRIPTION
This PR resolves the buggy colors in roman_rubin_2023_v0.1.0 and roman_rubin_2023_v0.1.1

This bug was introduced by me in 9dbc170462625f34faecea4c4e2fa5a0ab25a5c9. At the time of this commit, I noticed that the [_get_burstshape_galpop_from_params](https://github.com/ArgonneCPAC/diffsky/blob/f808cb26eeedd12a1a02c3bf053a7cc7760b37e1/diffsky/experimental/dspspop/burstshapepop.py#L49) function diffsky function was being called inside the [get_diffsky_sed_info](https://github.com/LSSTDESC/lsstdesc-diffsky/blob/9571879710acd076c5f59a7384382ca983090b65/lsstdesc_diffsky/photometry/photometry_lc_interp.py#L79) function. However, inside get_diffsky_sed_info function, the function named `_get_burstshape_galpop_from_params` is actually being passed `burstshapepop_u_params`, i.e., the _unbounded_ versions of the DiffburstShapePop model. This confused me because of the naming scheme I try to adopt consistently throughout all the Diff+ codes: functions whose names end in `_something_params` always accept _bounded_ parameters, whereas functions whose names end in `_something_u_params` instead always accept _unbounded_ parameters. So in 9dbc170462625f34faecea4c4e2fa5a0ab25a5c9, what I did was change the function that was called from  `_get_burstshape_galpop_from_params` to `_get_burstshape_galpop_from_u_params`.  I thought I was fixing a bug, but in fact I was _introducing_ a new bug. The reason is that, confusingly, the `_get_burstshape_galpop_from_params` is actually in reality accepting _unbounded_ parameters, and so this function actually violates the intended naming scheme.

This PR resolves this bug by modifying `get_diffsky_sed_info` to instead call `_get_burstshape_galpop_from_params`, as it was prior to 9dbc170462625f34faecea4c4e2fa5a0ab25a5c9. In preparing this PR, I grepped for all other uses of the `diffburstshapepop.py` module, and I found two other examples of this same mistake: within the [calc_rest_sed_singlegal](https://github.com/LSSTDESC/lsstdesc-diffsky/blob/9571879710acd076c5f59a7384382ca983090b65/lsstdesc_diffsky/sed/sed_kernels.py#L42C5-L42C28) function and within the [calc_rest_sed_disk_bulge_knot_singlegal](https://github.com/LSSTDESC/lsstdesc-diffsky/blob/9571879710acd076c5f59a7384382ca983090b65/lsstdesc_diffsky/sed/disk_bulge_sed_kernels.py#L63) function. It makes sense that these two functions also have this same bug, because I wrote these function by essentially pattern-matching the code within the `get_diffsky_sed_info` function _after_ commit 9dbc170462625f34faecea4c4e2fa5a0ab25a5c9.

In a local version of the code in which I have 4216fc7c5e0f545bcac1f1ffcb994c6669ea6fa3 installed (the HEAD commit of this PR), I am able to simply reingest the current version of the mock, `roman_rubin_2023_v0.1.0`, and make the following plot after recomputing the photometry from scratch.

![diffsky_cosmos_zy_redshift_magi23_bugfix_pr](https://github.com/LSSTDESC/lsstdesc-diffsky/assets/6951595/192aad7e-9e0a-4afc-9469-49dd5f828926)

@evevkovacs 