### PR TITLE
Resolve deprecation warning in pecZ.py module

### DIFF
--- a/lsstdesc_diffsky/pecZ.py
+++ b/lsstdesc_diffsky/pecZ.py
@@ -1,13 +1,14 @@
 """
 
 """
-from astropy.cosmology import WMAP7 as cosmo
 import astropy.constants as const
-from numpy.core import umath_tests as npm
 import numpy as np
-import warnings
+from astropy.cosmology import WMAP7 as cosmo
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import vmap
 
-warnings.filterwarnings("ignore", category=DeprecationWarning)
+dot_vmap = jjit(vmap(jnp.dot, in_axes=(0, 0)))
 
 
 def pecZ(x, y, z, vx, vy, vz, z_hubb, obs=np.zeros(3)):
@@ -28,7 +29,7 @@ def pecZ(x, y, z, vx, vy, vz, z_hubb, obs=np.zeros(3)):
     :param obs: The coordinates of the observer, in form [x, y, z]
     Returns
     -------
-             - the peculair z_hubb in each object in form of param redshift
+             - the peculiar z_hubb in each object in form of param redshift
              - the total observed z_hubb (cosmological+peculiar)
              - the peculiar velocity of each object, in the form of param vx,
                where negative velocities are toward the observer, in comoving km/s
@@ -45,7 +46,7 @@ def pecZ(x, y, z, vx, vy, vz, z_hubb, obs=np.zeros(3)):
 
     # dot velocity vectors with relative position unit vector to get peculiar velocity
     v = np.array([vx, vy, vz]).T
-    v_pec = npm.inner1d(v, r_rel_hat)
+    v_pec = dot_vmap(v, r_rel_hat)
 
     # find total and peculiar z_hubb (full relativistic expression)
     c = const.c.value / 1000

--- a/lsstdesc_diffsky/tests/test_pecZ.py
+++ b/lsstdesc_diffsky/tests/test_pecZ.py
@@ -1,0 +1,26 @@
+"""
+"""
+import numpy as np
+
+from ..pecZ import pecZ
+
+EPS = 1e-3
+
+
+def test_pecZ():
+    n = 100
+    Lbox = 1_000
+    x = np.random.uniform(0, Lbox, n)
+    y = np.random.uniform(0, Lbox, n)
+    z = np.random.uniform(0, Lbox, n)
+    vx = np.random.uniform(-100, 100, n)
+    vy = np.random.uniform(-100, 100, n)
+    vz = np.random.uniform(-100, 100, n)
+    z_hubb = np.random.uniform(0, 3, n)
+    _res = pecZ(x, y, z, vx, vy, vz, z_hubb)
+    for _x in _res:
+        assert np.all(np.isfinite(_x))
+        assert _x.shape == (n,)
+    z_pec, z_tot, v_pec, v_peca, r_rel_mag, r_rel_maga, r_dist = _res
+    assert np.all(z_pec > -EPS)
+    assert np.all(z_tot > -EPS)


### PR DESCRIPTION
This PR resolves a deprecation warning in pecZ.py by replacing the use of `numpy.core.umath_tests.inner1d` with a vectorized call to `jnp.dot`. 

Previously, the `pecZ` function computed the peculiar velocity `v_pec` like this:

`v_pec = numpy.core.umath_tests.inner1d(v, r_rel_hat)
`

The above line of code computes the elementwise dot product between `v` and `r_rel_hat`. Presumably, `inner1d` was used because `np.dot` only computes the dot product between a single pair of vectors, rather than an array of vectors. But importing from `numpy.core.umath_tests` triggers a deprecation warning notifying us that this will break in future. The previous implementation addressed this warning by ignoring it:

`warnings.filterwarnings("ignore", category=DeprecationWarning)`

This PR instead resolves this deprecation warning by computing the elementwise peculiar velocity by using JAX to vectorize `jnp.dot` as follows:
```
from jax import vmap, jit as jjit, numpy as jnp
dot_vmap = jjit(vmap(jnp.dot, in_axes=(0, 0)))
v_pec = dot_vmap(v, r_rel_hat)
```

This change was not straightforward to implement because `pecZ.py` had no testing. But there is now a new `test_pecZ.py` module that implements a basic unit test ensuring that at least the pecZ function returns finite-valued arrays of the expected shape.

CC @evevkovacs 

