### PR TITLE
Kernels and driver scripts for single-metallicity mocks

### DIFF
--- a/lsstdesc_diffsky/constants.py
+++ b/lsstdesc_diffsky/constants.py
@@ -1,4 +1,6 @@
 """This module stores globals used throughout the repository."""
+from copy import deepcopy
+
 from .disk_bulge_modeling.disk_bulge_kernels import DEFAULT_FBULGE_PDICT
 
 MAH_PNAMES = [
@@ -42,3 +44,8 @@ SED_params = {
         "filter_trans",
     ],
 }
+
+SED_params_singlemet = deepcopy(SED_params)
+xkeys = deepcopy(SED_params_singlemet["xkeys"])
+xkeys.pop(xkeys.index("ssp_lgmet"))
+SED_params_singlemet["xkeys"] = xkeys

--- a/lsstdesc_diffsky/legacy/roman_rubin_2023/dsps/data_loaders/defaults.py
+++ b/lsstdesc_diffsky/legacy/roman_rubin_2023/dsps/data_loaders/defaults.py
@@ -4,6 +4,7 @@ import typing
 import numpy as np
 
 DEFAULT_SSP_BNAME = "ssp_data_fsps_v3.2_lgmet_age.h5"
+DEFAULT_SSP_BNAME_SINGLEMET = "ssp_data_fsps_v3.2_age.h5"
 
 
 class SSPData(typing.NamedTuple):
@@ -48,6 +49,9 @@ class SSPDataSingleMet(typing.NamedTuple):
     ssp_lg_age_gyr: np.ndarray
     ssp_wave: np.ndarray
     ssp_flux: np.ndarray
+
+
+SSP_KEYS_SINGLEMET = SSPDataSingleMet._fields
 
 
 class TransmissionCurve(typing.NamedTuple):

--- a/lsstdesc_diffsky/legacy/roman_rubin_2023/dsps/data_loaders/load_ssp_data.py
+++ b/lsstdesc_diffsky/legacy/roman_rubin_2023/dsps/data_loaders/load_ssp_data.py
@@ -5,7 +5,14 @@ from collections import OrderedDict
 
 import h5py
 
-from .defaults import DEFAULT_SSP_BNAME, DEFAULT_SSP_KEYS, SSPData, SSPDataSingleMet
+from .defaults import (
+    DEFAULT_SSP_BNAME,
+    DEFAULT_SSP_BNAME_SINGLEMET,
+    DEFAULT_SSP_KEYS,
+    SSP_KEYS_SINGLEMET,
+    SSPData,
+    SSPDataSingleMet,
+)
 from .retrieve_fake_fsps_data import load_fake_ssp_data
 
 
@@ -75,7 +82,11 @@ def load_ssp_templates(
 
 
 def load_ssp_templates_singlemet(
-    fn=None, drn=None, bn=DEFAULT_SSP_BNAME, ssp_keys=DEFAULT_SSP_KEYS, dummy=False
+    fn=None,
+    drn=None,
+    bn=DEFAULT_SSP_BNAME_SINGLEMET,
+    ssp_keys=SSP_KEYS_SINGLEMET,
+    dummy=False,
 ):
     """Load SSP templates from disk, defaulting to DSPS package data location
 
@@ -105,7 +116,7 @@ def load_ssp_templates_singlemet(
 
         ssp_wave : ndarray of shape (n_wave, )
 
-        ssp_flux : ndarray of shape (n_met, n_ages, n_wave)
+        ssp_flux : ndarray of shape (n_ages, n_wave)
             SED of the SSP in units of Lsun/Hz/Msun
 
     """

--- a/lsstdesc_diffsky/photometry/photometry_interpolation_kernels.py
+++ b/lsstdesc_diffsky/photometry/photometry_interpolation_kernels.py
@@ -80,6 +80,10 @@ _calc_rest_mag_vmap_f_ssp = jjit(
     )
 )
 
+_calc_rest_mag_vmap_f_ssp_singlemet = jjit(
+    vmap(_calc_rest_mag_vmap_f, in_axes=[None, 0, None, None]),
+)
+
 
 @jjit
 def _get_filter_effective_wavelength_rest(filter_wave, filter_trans):

--- a/lsstdesc_diffsky/photometry/photometry_interpolation_kernels.py
+++ b/lsstdesc_diffsky/photometry/photometry_interpolation_kernels.py
@@ -66,6 +66,12 @@ _calc_obs_mag_vmap_f_ssp = jjit(
 )
 _calc_obs_mag_vmap_f_ssp_z = jjit(vmap(_calc_obs_mag_vmap_f_ssp, in_axes=_z))
 
+_calc_obs_mag_vmap_f_ssp_singlemet = jjit(vmap(_calc_obs_mag_vmap_f, in_axes=_ssp))
+_calc_obs_mag_vmap_f_ssp_z_singlemet = jjit(
+    vmap(_calc_obs_mag_vmap_f_ssp_singlemet, in_axes=_z)
+)
+
+
 _calc_rest_mag_vmap_f = jjit(vmap(calc_rest_mag, in_axes=[None, None, 0, 0]))
 _calc_rest_mag_vmap_f_ssp = jjit(
     vmap(

--- a/lsstdesc_diffsky/photometry/photometry_lc_interp_singlemet.py
+++ b/lsstdesc_diffsky/photometry/photometry_lc_interp_singlemet.py
@@ -73,7 +73,7 @@ class DiffskySEDinfo(typing.NamedTuple):
     gal_restmags_dust: jnp.ndarray
 
 
-def get_diffsky_sed_info(
+def get_diffsky_sed_info_singlemet(
     ran_key,
     gal_z_obs,
     mah_params,

--- a/lsstdesc_diffsky/photometry/photometry_lc_interp_singlemet.py
+++ b/lsstdesc_diffsky/photometry/photometry_lc_interp_singlemet.py
@@ -91,12 +91,7 @@ def get_diffsky_sed_info(
     rest_filter_trans,
     obs_filter_waves,
     obs_filter_trans,
-    lgfburst_pop_u_params,
-    burstshapepop_u_params,
-    lgav_u_params,
-    dust_delta_u_params,
-    fracuno_pop_u_params,
-    met_params,
+    diffskypop_params,
     cosmo_params,
 ):
     """Compute SED and photometry for population of Diffsky galaxies
@@ -265,7 +260,10 @@ def get_diffsky_sed_info(
     n_gals, n_met, n_age, n_obs_filters = ssp_obsmag_table_pergal.shape
     n_rest_filters = ssp_restmag_table.shape[-1]
 
-    mzr_params, lgmet_scatter = met_params[:-1], met_params[-1]
+    mzr_params, lgmet_scatter = (
+        diffskypop_params.lgmet_params[:-1],
+        diffskypop_params.lgmet_params[-1],
+    )
 
     # Compute various galaxy properties at z_obs
     _galprops = _get_galprops_at_t_obs(
@@ -294,13 +292,13 @@ def get_diffsky_sed_info(
 
     # Compute burst fraction for every galaxy
     gal_lgf_burst = _get_lgfburst_galpop_from_u_params(
-        gal_logsm_t_obs, gal_logssfr_t_obs, lgfburst_pop_u_params
+        gal_logsm_t_obs, gal_logssfr_t_obs, diffskypop_params.lgfburst_u_params
     )
     gal_fburst = 10**gal_lgf_burst
 
     # Compute P(τ) for each bursting population
     gal_u_lgyr_peak, gal_u_lgyr_max = _get_burstshape_galpop_from_params(
-        gal_logsm_t_obs, gal_logssfr_t_obs, burstshapepop_u_params
+        gal_logsm_t_obs, gal_logssfr_t_obs, diffskypop_params.burstshape_u_params
     )
     burstshape_u_params = jnp.array((gal_u_lgyr_peak, gal_u_lgyr_max)).T
     ssp_lg_age_yr = ssp_data.ssp_lg_age_gyr + 9
@@ -351,9 +349,9 @@ def get_diffsky_sed_info(
         ssp_data.ssp_lg_age_gyr,
         obs_filter_waves,
         obs_filter_trans,
-        lgav_u_params,
-        dust_delta_u_params,
-        fracuno_pop_u_params,
+        diffskypop_params.lgav_dust_u_params,
+        diffskypop_params.delta_dust_u_params,
+        diffskypop_params.funo_dust_u_params,
     )
     gal_frac_trans_obs = _dust_results_obs[0]  # (n_gals, n_age, n_filters)
     gal_att_curve_params, gal_frac_unobs = _dust_results_obs[1:]
@@ -374,9 +372,9 @@ def get_diffsky_sed_info(
         ssp_data.ssp_lg_age_gyr,
         rest_filter_waves,
         rest_filter_trans,
-        lgav_u_params,
-        dust_delta_u_params,
-        fracuno_pop_u_params,
+        diffskypop_params.lgav_dust_u_params,
+        diffskypop_params.delta_dust_u_params,
+        diffskypop_params.funo_dust_u_params,
     )
     gal_frac_trans_rest = _dust_results_rest[0]  # (n_gals, n_age, n_filters)
 

--- a/lsstdesc_diffsky/photometry/photometry_lc_interp_singlemet.py
+++ b/lsstdesc_diffsky/photometry/photometry_lc_interp_singlemet.py
@@ -85,8 +85,7 @@ def get_diffsky_sed_info(
     ssp_z_table,
     ssp_restmag_table,
     ssp_obsmag_table,
-    ssp_lgmet,
-    ssp_lg_age_gyr,
+    ssp_data,
     gal_t_table,
     rest_filter_waves,
     rest_filter_trans,
@@ -286,8 +285,8 @@ def get_diffsky_sed_info(
         gal_sfr_table,
         gal_lgmet_t_obs,
         lgmet_scatter,
-        ssp_lgmet,
-        ssp_lg_age_gyr,
+        ssp_data.ssp_lgmet,
+        ssp_data.ssp_lg_age_gyr,
         gal_t_obs,
     )
     _weights = calc_ssp_weights_sfh_table_lognormal_mdf_vmap(*args)
@@ -304,7 +303,7 @@ def get_diffsky_sed_info(
         gal_logsm_t_obs, gal_logssfr_t_obs, burstshapepop_u_params
     )
     burstshape_u_params = jnp.array((gal_u_lgyr_peak, gal_u_lgyr_max)).T
-    ssp_lg_age_yr = ssp_lg_age_gyr + 9
+    ssp_lg_age_yr = ssp_data.ssp_lg_age_gyr + 9
     burst_age_weights = _burst_age_weights_from_u_params_vmap(
         ssp_lg_age_yr, burstshape_u_params
     )
@@ -349,7 +348,7 @@ def get_diffsky_sed_info(
         gal_logsm_t_obs,
         gal_logssfr_t_obs,
         gal_lgf_burst,
-        ssp_lg_age_gyr,
+        ssp_data.ssp_lg_age_gyr,
         obs_filter_waves,
         obs_filter_trans,
         lgav_u_params,
@@ -372,7 +371,7 @@ def get_diffsky_sed_info(
         gal_logsm_t_obs,
         gal_logssfr_t_obs,
         gal_lgf_burst,
-        ssp_lg_age_gyr,
+        ssp_data.ssp_lg_age_gyr,
         rest_filter_waves,
         rest_filter_trans,
         lgav_u_params,

--- a/lsstdesc_diffsky/photometry/photometry_lc_interp_singlemet.py
+++ b/lsstdesc_diffsky/photometry/photometry_lc_interp_singlemet.py
@@ -9,15 +9,6 @@ bulge, diffuse disk, star-forming knots
 """
 import typing
 
-from diffsky.experimental.dspspop.burstshapepop import (
-    _get_burstshape_galpop_from_params,
-)
-from diffsky.experimental.dspspop.dustpop import (
-    _frac_dust_transmission_lightcone_kernel,
-    _frac_dust_transmission_singlez_kernel,
-)
-from diffsky.experimental.dspspop.lgfburstpop import _get_lgfburst_galpop_from_u_params
-from diffsky.experimental.photometry_interpolation import interpolate_ssp_photmag_table
 from diffstar import sfh_galpop
 from diffstar.defaults import SFR_MIN
 from dsps.cosmology.flat_wcdm import _age_at_z_vmap, age_at_z0
@@ -38,6 +29,13 @@ from jax import vmap
 from ..disk_bulge_modeling.disk_bulge_kernels import calc_tform_pop
 from ..disk_bulge_modeling.disk_knots import FKNOT_MAX
 from ..disk_bulge_modeling.mc_disk_bulge import _bulge_sfh_vmap, generate_fbulge_params
+from ..dspspop.burstshapepop import _get_burstshape_galpop_from_params
+from ..dspspop.dustpop import (
+    _frac_dust_transmission_lightcone_kernel,
+    _frac_dust_transmission_singlez_kernel,
+)
+from ..dspspop.lgfburstpop import _get_lgfburst_galpop_from_u_params
+from ..photometry_interpolation import interpolate_ssp_photmag_table
 
 _linterp_vmap = jjit(vmap(jnp.interp, in_axes=(0, None, 0)))
 
@@ -160,27 +158,27 @@ def get_diffsky_sed_info(
     lgfburst_pop_u_params : ndarray, shape (n_pars_lgfburst_pop, )
         Unbounded parameters controlling Fburst, which sets the fractional contribution
         of a recent burst to the smooth SFH of a galaxy. For typical values, see
-        diffsky.experimental.dspspop.lgfburstpop.DEFAULT_LGFBURST_U_PARAMS
+        dspspop.lgfburstpop.DEFAULT_LGFBURST_U_PARAMS
 
     burstshapepop_u_params : ndarray, shape (n_pars_burstshape_pop, )
         Unbounded parameters controlling the distribution of stellar ages
         of stars formed in a recent burst. For typical values, see
-        diffsky.experimental.dspspop.burstshapepop.DEFAULT_BURSTSHAPE_U_PARAMS
+        dspspop.burstshapepop.DEFAULT_BURSTSHAPE_U_PARAMS
 
     lgav_u_params : ndarray, shape (n_pars_lgav_pop, )
         Unbounded parameters controlling the distribution of dust parameter Av,
         the normalization of the attenuation curve at λ_V=5500 angstrom.
         For typical values, see
-        diffsky.experimental.dspspop.lgavpop.DEFAULT_LGAV_U_PARAMS
+        dspspop.lgavpop.DEFAULT_LGAV_U_PARAMS
 
     dust_delta_u_params : ndarray, shape (n_pars_dust_delta_pop, )
         Unbounded parameters controlling the distribution of dust parameter δ,
         which modifies the power-law slope of the attenuation curve. For typical values,
-        see diffsky.experimental.dspspop.dust_deltapop.DEFAULT_DUST_DELTA_U_PARAMS
+        see dspspop.dust_deltapop.DEFAULT_DUST_DELTA_U_PARAMS
 
     fracuno_pop_u_params : ndarray, shape (n_pars_fracuno_pop, )
         Unbounded parameters controlling the fraction of sightlines unobscured by dust.
-        For typical values, see diffsky.experimental.dspspop.boris_dust.DEFAULT_U_PARAMS
+        For typical values, see dspspop.boris_dust.DEFAULT_U_PARAMS
 
     met_params : ndarray, shape (n_pars_met_pop, ), optional
         Parameters controlling the mass-metallicity scaling relation.

--- a/lsstdesc_diffsky/photometry/photometry_lc_interp_singlemet.py
+++ b/lsstdesc_diffsky/photometry/photometry_lc_interp_singlemet.py
@@ -1,0 +1,490 @@
+"""Module implements two functions:
+
+1. get_diffsky_sed_info calculates composite the composite SED and photometry of
+a population of diffsky galaxies
+
+2. decompose_sfh_into_bulge_disk_knots decomposes the composite SED into 3 components:
+bulge, diffuse disk, star-forming knots
+
+"""
+import typing
+
+from diffsky.experimental.dspspop.burstshapepop import (
+    _get_burstshape_galpop_from_params,
+)
+from diffsky.experimental.dspspop.dustpop import (
+    _frac_dust_transmission_lightcone_kernel,
+    _frac_dust_transmission_singlez_kernel,
+)
+from diffsky.experimental.dspspop.lgfburstpop import _get_lgfburst_galpop_from_u_params
+from diffsky.experimental.photometry_interpolation import interpolate_ssp_photmag_table
+from diffstar import sfh_galpop
+from diffstar.defaults import SFR_MIN
+from dsps.cosmology.flat_wcdm import _age_at_z_vmap, age_at_z0
+from dsps.experimental.diffburst import (
+    _age_weights_from_u_params as _burst_age_weights_from_u_params,
+)
+from dsps.experimental.diffburst import (
+    _get_params_from_u_params as _get_burst_params_from_u_params,
+)
+from dsps.metallicity.mzr import mzr_model
+from dsps.sed import calc_ssp_weights_sfh_table_lognormal_mdf
+from dsps.sed.stellar_age_weights import _calc_logsm_table_from_sfh_table
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import random as jran
+from jax import vmap
+
+from ..disk_bulge_modeling.disk_bulge_kernels import calc_tform_pop
+from ..disk_bulge_modeling.disk_knots import FKNOT_MAX
+from ..disk_bulge_modeling.mc_disk_bulge import _bulge_sfh_vmap, generate_fbulge_params
+
+_linterp_vmap = jjit(vmap(jnp.interp, in_axes=(0, None, 0)))
+
+_g = (None, 0, 0, None, None, None, 0)
+calc_ssp_weights_sfh_table_lognormal_mdf_vmap = jjit(
+    vmap(calc_ssp_weights_sfh_table_lognormal_mdf, in_axes=_g)
+)
+
+_b = (None, 0, None)
+_calc_logsm_table_from_sfh_table_vmap = jjit(
+    vmap(_calc_logsm_table_from_sfh_table, in_axes=_b)
+)
+
+_A = (None, 0)
+_burst_age_weights_from_u_params_vmap = jjit(
+    vmap(_burst_age_weights_from_u_params, in_axes=_A)
+)
+
+_get_burst_params_from_u_params_vmap = jjit(vmap(_get_burst_params_from_u_params))
+
+
+class DiffskySEDinfo(typing.NamedTuple):
+    gal_ssp_weights: jnp.ndarray
+    gal_frac_trans_obs: jnp.ndarray
+    gal_frac_trans_rest: jnp.ndarray
+    gal_att_curve_params: jnp.ndarray
+    gal_frac_unobs: jnp.ndarray
+    gal_fburst: jnp.ndarray
+    gal_burstshape_params: jnp.ndarray
+    gal_frac_bulge_t_obs: jnp.ndarray
+    gal_fbulge_params: jnp.ndarray
+    gal_fknot: jnp.ndarray
+    gal_obsmags_nodust: jnp.ndarray
+    gal_restmags_nodust: jnp.ndarray
+    gal_obsmags_dust: jnp.ndarray
+    gal_restmags_dust: jnp.ndarray
+
+
+def get_diffsky_sed_info(
+    ran_key,
+    gal_z_obs,
+    mah_params,
+    ms_params,
+    q_params,
+    ssp_z_table,
+    ssp_restmag_table,
+    ssp_obsmag_table,
+    ssp_lgmet,
+    ssp_lg_age_gyr,
+    gal_t_table,
+    rest_filter_waves,
+    rest_filter_trans,
+    obs_filter_waves,
+    obs_filter_trans,
+    lgfburst_pop_u_params,
+    burstshapepop_u_params,
+    lgav_u_params,
+    dust_delta_u_params,
+    fracuno_pop_u_params,
+    met_params,
+    cosmo_params,
+):
+    """Compute SED and photometry for population of Diffsky galaxies
+
+    Parameters
+    ----------
+    ran_key : jax.random.PRNGKey
+        Random number seed used to assign values for disk/bulge/knot decomposition
+
+    gal_z_obs : ndarray, shape (n_gals, )
+        Redshift of each galaxy
+
+    mah_params : ndarray, shape (n_gals, 4)
+        Diffmah params specifying the mass assembly of the dark matter halo
+        diffmah_params = (logm0, logtc, early_index, late_index)
+
+    ms_params : ndarray, shape (n_gals, 5)
+        Diffstar params for the star-formation effiency and gas consumption timescale
+        ms_params = (lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep)
+
+    q_params : ndarray, shape (n_gals, 4)
+        Diffstar quenching params, (lg_qt, qlglgdt, lg_drop, lg_rejuv)
+
+    ssp_z_table : ndarray, shape (n_z_table, )
+        Table storing a grid in redshift at which SSP photometry have been precomputed
+
+    ssp_restmag_table : ndarray, shape (n_met, n_age, n_rest_filters)
+        Restframe AB magnitude of SSPs integrated across input transmission curves
+        for n_rest_filters filters
+
+    ssp_obsmag_table : ndarray, shape (n_z_table, n_met, n_age, n_obs_filters)
+        Apparent AB magnitude of SSPs observed on a redshift grid with n_z_table points
+        for n_obs_filters filters
+
+    ssp_lgmet : ndarray, shape (n_met, )
+        Grid in metallicity Z at which the SSPs are computed, stored as log10(Z)
+
+    ssp_lg_age_gyr : ndarray, shape (n_age, )
+        Grid in age τ at which the SSPs are computed, stored as log10(τ/Gyr)
+
+    gal_t_table : ndarray, shape (n_t, )
+        Grid in cosmic time t in Gyr at which SFH of the galaxy population is tabulated
+        gal_t_table should increase monotonically and it should span the
+        full range of gal_t_obs, including some padding of a few million years
+
+    rest_filter_waves : ndarray, shape (n_rest_filters, n_trans_wave)
+        Grid in λ in angstroms at which n_rest_filters filter transmission
+        curves are defined.
+
+        Note that each observer- and rest-frame filter transmission curve must be
+        specified by a λ-grid with the same number of points.
+
+    rest_filter_trans : ndarray, shape (n_rest_filters, n_trans_wave)
+        Transmission curves of n_rest_filters for photometry restframe absolute mags
+
+    obs_filter_waves : ndarray, shape (n_obs_filters, n_trans_wave)
+        Grid in λ in angstroms at which n_obs_filters filter transmission
+        curves are defined
+
+        Note that each observer- and rest-frame filter transmission curve must be
+        specified by a λ-grid with the same number of points.
+
+    obs_filter_trans : ndarray, shape (n_obs_filters, n_trans_wave)
+        Transmission curves of n_obs_filters for photometry apparent mags
+
+    lgfburst_pop_u_params : ndarray, shape (n_pars_lgfburst_pop, )
+        Unbounded parameters controlling Fburst, which sets the fractional contribution
+        of a recent burst to the smooth SFH of a galaxy. For typical values, see
+        diffsky.experimental.dspspop.lgfburstpop.DEFAULT_LGFBURST_U_PARAMS
+
+    burstshapepop_u_params : ndarray, shape (n_pars_burstshape_pop, )
+        Unbounded parameters controlling the distribution of stellar ages
+        of stars formed in a recent burst. For typical values, see
+        diffsky.experimental.dspspop.burstshapepop.DEFAULT_BURSTSHAPE_U_PARAMS
+
+    lgav_u_params : ndarray, shape (n_pars_lgav_pop, )
+        Unbounded parameters controlling the distribution of dust parameter Av,
+        the normalization of the attenuation curve at λ_V=5500 angstrom.
+        For typical values, see
+        diffsky.experimental.dspspop.lgavpop.DEFAULT_LGAV_U_PARAMS
+
+    dust_delta_u_params : ndarray, shape (n_pars_dust_delta_pop, )
+        Unbounded parameters controlling the distribution of dust parameter δ,
+        which modifies the power-law slope of the attenuation curve. For typical values,
+        see diffsky.experimental.dspspop.dust_deltapop.DEFAULT_DUST_DELTA_U_PARAMS
+
+    fracuno_pop_u_params : ndarray, shape (n_pars_fracuno_pop, )
+        Unbounded parameters controlling the fraction of sightlines unobscured by dust.
+        For typical values, see diffsky.experimental.dspspop.boris_dust.DEFAULT_U_PARAMS
+
+    met_params : ndarray, shape (n_pars_met_pop, ), optional
+        Parameters controlling the mass-metallicity scaling relation.
+        For typical values, see dsps.metallicity.mzr.DEFAULT_MZR_PDICT
+        mzr_params = met_params[:-1]
+        lgmet_scatter = met_params[-1]
+
+    cosmo_params : ndarray, shape (n_cosmo, )
+        Defined in lsstdesc_diffsky.defaults, cosmo_params = (Om0, w0, wa, h, fb)
+
+    Returns
+    ----------
+    gal_weights : ndarray, shape (n_gals, n_met, n_age)
+        Probability distribution P(Z, τ_age) for each galaxy
+
+    gal_frac_trans_obs : ndarray, shape (n_gals, n_age, n_obs_filters)
+        For each galaxy, array stores the fraction of light transmitted through dust
+        as a function of τ_age and filter bandpass used in observer-frame magnitudes
+
+    gal_frac_trans_rest : ndarray, shape (n_gals, n_age, n_rest_filters)
+        For each galaxy, array stores the fraction of light transmitted through dust
+        as a function of τ_age and filter bandpass used in rest-frame magnitudes
+
+    gal_att_curve_params : ndarray, shape (n_gals, 3)
+        Dust attenuation curve parameters (dust_eb, dust_delta, dust_av) for each galaxy
+
+    gal_frac_unobs : ndarray, shape (n_gals, n_age)
+        Unobscured fraction for every galaxy at every τ_age
+
+    gal_fburst : ndarray, shape (n_gals, )
+        Fraction of the galaxy mass in the bursting population at gal_t_obs
+
+    gal_burstshape_params : ndarray, shape (n_gals, 2)
+        Parameters controlling P(τ) for burst population in each galaxy
+        lgyr_peak = gal_burstshape_params[:, 0]
+        lgyr_max = gal_burstshape_params[:, 1]
+
+    gal_frac_bulge_t_obs : ndarray, shape (n_gals, )
+        Bulge/total mass ratio at gal_t_obs for every galaxy
+
+    gal_fbulge_params : ndarray, shape (n_gals, 3)
+        Bulge parameters (fbulge_tcrit, fbulge_early, fbulge_late) for each galaxy
+
+    gal_fknot : ndarray, shape (n_gals, )
+        Fraction of the disk mass in bursty star-forming knots for each galaxy
+
+    gal_obsmags_nodust : ndarray, shape (n_gals, n_obs_filters)
+        Apparent AB magnitude of each galaxy through each filter,
+        neglecting dust attenuation
+
+    gal_restmags_nodust : ndarray, shape (n_gals, n_rest_filters)
+        Rest-frame AB magnitude of each galaxy through each filter,
+        neglecting dust attenuation
+
+    gal_obsmags_dust : ndarray, shape (n_gals, n_obs_filters)
+        Apparent AB magnitude of each galaxy through each filter,
+        accounting for dust attenuation
+
+    gal_restmags_dust : ndarray, shape (n_gals, n_rest_filters)
+        Rest-frame AB magnitude of each galaxy through each filter,
+        accounting for dust attenuation
+
+    """
+    # Bounds check input arguments and extract array shapes and sizes
+    _check_ssp_info_shapes(ssp_z_table, gal_z_obs)
+
+    fb = cosmo_params[-1]
+    t0 = age_at_z0(*cosmo_params[:-1])
+    lgt0 = jnp.log10(t0)
+    gal_sfr_table = sfh_galpop(
+        gal_t_table, mah_params, ms_params, q_params, lgt0=lgt0, fb=fb
+    )
+
+    ssp_obsmag_table_pergal = _get_ssp_obsmag_table_pergal(
+        gal_z_obs, ssp_z_table, ssp_obsmag_table, ssp_restmag_table, gal_sfr_table
+    )
+    n_gals, n_met, n_age, n_obs_filters = ssp_obsmag_table_pergal.shape
+    n_rest_filters = ssp_restmag_table.shape[-1]
+
+    mzr_params, lgmet_scatter = met_params[:-1], met_params[-1]
+
+    # Compute various galaxy properties at z_obs
+    _galprops = _get_galprops_at_t_obs(
+        gal_z_obs, gal_t_table, gal_sfr_table, mzr_params, cosmo_params
+    )
+    gal_t_obs, gal_logsm_t_obs, gal_logssfr_t_obs, gal_lgmet_t_obs = _galprops[:4]
+    gal_t10, gal_t90, gal_logsm0 = _galprops[4:]
+
+    # Monte Carlo generate morphology parameters
+    fbulge_key, knot_key = jran.split(ran_key, 2)
+    gal_fbulge_params = generate_fbulge_params(fbulge_key, gal_t10, gal_t90, gal_logsm0)
+    gal_fknot = jran.uniform(knot_key, minval=0, maxval=FKNOT_MAX, shape=(n_gals,))
+
+    # Compute P(Z) and P(τ) for every galaxy
+    args = (
+        gal_t_table,
+        gal_sfr_table,
+        gal_lgmet_t_obs,
+        lgmet_scatter,
+        ssp_lgmet,
+        ssp_lg_age_gyr,
+        gal_t_obs,
+    )
+    _weights = calc_ssp_weights_sfh_table_lognormal_mdf_vmap(*args)
+    lgmet_weights, smooth_age_weights = _weights[1:]
+
+    # Compute burst fraction for every galaxy
+    gal_lgf_burst = _get_lgfburst_galpop_from_u_params(
+        gal_logsm_t_obs, gal_logssfr_t_obs, lgfburst_pop_u_params
+    )
+    gal_fburst = 10**gal_lgf_burst
+
+    # Compute P(τ) for each bursting population
+    gal_u_lgyr_peak, gal_u_lgyr_max = _get_burstshape_galpop_from_params(
+        gal_logsm_t_obs, gal_logssfr_t_obs, burstshapepop_u_params
+    )
+    burstshape_u_params = jnp.array((gal_u_lgyr_peak, gal_u_lgyr_max)).T
+    ssp_lg_age_yr = ssp_lg_age_gyr + 9
+    burst_age_weights = _burst_age_weights_from_u_params_vmap(
+        ssp_lg_age_yr, burstshape_u_params
+    )
+
+    gal_lgyr_peak, gal_lgyr_max = _get_burst_params_from_u_params_vmap(
+        burstshape_u_params
+    )
+    gal_burstshape_params = jnp.array((gal_lgyr_peak, gal_lgyr_max)).T
+
+    # Compute P(τ) for each composite galaxy
+    _fb = gal_fburst.reshape((n_gals, 1))
+    gal_age_weights = _fb * burst_age_weights + (1 - _fb) * smooth_age_weights
+
+    # Compute P(τ, Z) for each composite galaxy
+    _w_age = gal_age_weights.reshape((n_gals, 1, n_age))
+    _w_met = lgmet_weights.reshape((n_gals, n_met, 1))
+    _w = _w_age * _w_met
+    _norm = jnp.sum(_w, axis=(1, 2))
+    gal_weights = _w / _norm.reshape((n_gals, 1, 1))  # (n_gals, n_met, n_age)
+    gal_weights = gal_weights.reshape((n_gals, n_met, n_age, 1))
+
+    # Compute observed stellar mass for each composite galaxy
+    gal_mstar_obs = (10**gal_logsm_t_obs).reshape((n_gals, 1))
+
+    # Compute apparent magnitude in each band for each composite galaxy neglecting dust
+    ssp_obsflux_table_pergal = 10 ** (-0.4 * ssp_obsmag_table_pergal)
+    prod_obs_nodust = gal_weights * ssp_obsflux_table_pergal
+    gal_obsflux_nodust = jnp.sum(prod_obs_nodust, axis=(1, 2)) * gal_mstar_obs
+    gal_obsmags_nodust = -2.5 * jnp.log10(gal_obsflux_nodust)
+
+    # Compute restframe magnitude in each band for each composite galaxy neglecting dust
+    ssp_restflux_table = 10 ** (-0.4 * ssp_restmag_table)
+    prod_rest = gal_weights * ssp_restflux_table
+    gal_restflux_nodust = jnp.sum(prod_rest, axis=(1, 2)) * gal_mstar_obs
+    gal_restmags_nodust = -2.5 * jnp.log10(gal_restflux_nodust)
+
+    # Compute attenuation through each observed filter bandpass
+    dummy_dust_key = 0
+    _dust_results_obs = _frac_dust_transmission_lightcone_kernel(
+        dummy_dust_key,
+        gal_z_obs,
+        gal_logsm_t_obs,
+        gal_logssfr_t_obs,
+        gal_lgf_burst,
+        ssp_lg_age_gyr,
+        obs_filter_waves,
+        obs_filter_trans,
+        lgav_u_params,
+        dust_delta_u_params,
+        fracuno_pop_u_params,
+    )
+    gal_frac_trans_obs = _dust_results_obs[0]  # (n_gals, n_age, n_filters)
+    gal_att_curve_params, gal_frac_unobs = _dust_results_obs[1:]
+
+    # Apply dust attenuation to the apparent magnitude in each band for each galaxy
+    ft_obs = gal_frac_trans_obs.reshape((n_gals, 1, n_age, n_obs_filters))
+    prod_obs_dust = gal_weights * ssp_obsflux_table_pergal * ft_obs
+    gal_obsflux_dust = jnp.sum(prod_obs_dust, axis=(1, 2)) * gal_mstar_obs
+    gal_obsmags_dust = -2.5 * jnp.log10(gal_obsflux_dust)
+
+    # Compute attenuation through each restframe filter bandpass
+    _dust_results_rest = _frac_dust_transmission_singlez_kernel(
+        dummy_dust_key,
+        0.0,
+        gal_logsm_t_obs,
+        gal_logssfr_t_obs,
+        gal_lgf_burst,
+        ssp_lg_age_gyr,
+        rest_filter_waves,
+        rest_filter_trans,
+        lgav_u_params,
+        dust_delta_u_params,
+        fracuno_pop_u_params,
+    )
+    gal_frac_trans_rest = _dust_results_rest[0]  # (n_gals, n_age, n_filters)
+
+    # Apply dust attenuation to the restframe magnitude in each band for each galaxy
+    ft_rest = gal_frac_trans_rest.reshape((n_gals, 1, n_age, n_rest_filters))
+    prod_rest_dust = gal_weights * ssp_restflux_table * ft_rest
+    gal_restflux_dust = jnp.sum(prod_rest_dust, axis=(1, 2)) * gal_mstar_obs
+    gal_restmags_dust = -2.5 * jnp.log10(gal_restflux_dust)
+
+    _res = _bulge_sfh_vmap(gal_t_table, gal_sfr_table, gal_fbulge_params)
+    smh, eff_bulge, bulge_sfh, smh_bulge, bulge_to_total_history = _res
+
+    bulge_sfh = jnp.where(bulge_sfh < SFR_MIN, SFR_MIN, bulge_sfh)
+    gal_frac_bulge_t_obs = _linterp_vmap(gal_t_obs, gal_t_table, bulge_to_total_history)
+
+    gal_ssp_weights = gal_weights.reshape((n_gals, n_met, n_age))
+    sed_info = DiffskySEDinfo(
+        gal_ssp_weights,
+        gal_frac_trans_obs,
+        gal_frac_trans_rest,
+        gal_att_curve_params,
+        gal_frac_unobs,
+        gal_fburst,
+        gal_burstshape_params,
+        gal_frac_bulge_t_obs,
+        gal_fbulge_params,
+        gal_fknot,
+        gal_obsmags_nodust,
+        gal_restmags_nodust,
+        gal_obsmags_dust,
+        gal_restmags_dust,
+    )
+    return sed_info
+
+
+def _get_galprops_at_t_obs(
+    gal_z_obs, gal_t_table, gal_sfr_table, mzr_params, cosmo_params
+):
+    Om0, w0, wa, h, fb = cosmo_params
+    gal_t_obs = _age_at_z_vmap(gal_z_obs, Om0, w0, wa, h)
+    lgt_obs = jnp.log10(gal_t_obs)
+    lgt_table = jnp.log10(gal_t_table)
+
+    gal_sfr_table = jnp.where(gal_sfr_table < SFR_MIN, SFR_MIN, gal_sfr_table)
+    gal_logsm_table = _calc_logsm_table_from_sfh_table_vmap(
+        gal_t_table, gal_sfr_table, SFR_MIN
+    )
+    gal_logsfr_table = jnp.log10(gal_sfr_table)
+
+    gal_logsm_t_obs = _linterp_vmap(lgt_obs, lgt_table, gal_logsm_table)
+    gal_logsfr_t_obs = _linterp_vmap(lgt_obs, lgt_table, gal_logsfr_table)
+    gal_logssfr_t_obs = gal_logsfr_t_obs - gal_logsm_t_obs
+
+    gal_smh_table = 10**gal_logsm_table
+    gal_t10 = calc_tform_pop(gal_t_table, gal_smh_table, 0.1)
+    gal_t90 = calc_tform_pop(gal_t_table, gal_smh_table, 0.9)
+    gal_logsm0 = gal_smh_table[:, -1]
+
+    gal_lgmet_t_obs = mzr_model(gal_logsm_t_obs, gal_t_obs, *mzr_params)
+
+    return (
+        gal_t_obs,
+        gal_logsm_t_obs,
+        gal_logssfr_t_obs,
+        gal_lgmet_t_obs,
+        gal_t10,
+        gal_t90,
+        gal_logsm0,
+    )
+
+
+def _check_ssp_info_shapes(ssp_z_table, gal_z_obs):
+    msg = "ssp_z_table must be monotonically increasing"
+    assert jnp.all(jnp.diff(ssp_z_table) > 0), msg
+
+    msg = "Must have ssp_z_table.min() < gal_z_obs.min()"
+    assert jnp.all(ssp_z_table.min() < gal_z_obs.min()), msg
+
+    msg = "Must have ssp_z_table.max() > gal_z_obs.max()"
+    assert jnp.all(ssp_z_table.max() > gal_z_obs.max()), msg
+
+
+def _get_ssp_obsmag_table_pergal(
+    gal_z_obs, ssp_z_table, ssp_obsmag_table, ssp_restmag_table, gal_sfr_table
+):
+    ssp_obsmag_table_pergal = interpolate_ssp_photmag_table(
+        gal_z_obs, ssp_z_table, ssp_obsmag_table
+    )
+    n_gals, n_met, n_age, n_obs_filters = ssp_obsmag_table_pergal.shape
+
+    msg = "gal_sfr_table.shape[0]={0} must equal gal_z_obs.shape[0]={1}"
+    _n_gals = gal_sfr_table.shape[0]
+    assert n_gals == gal_sfr_table.shape[0], msg.format(n_gals, _n_gals)
+
+    msg = "ssp_lgmet.shape[0]={0} must equal ssp_obsmag_table_pergal.shape[1]={1}"
+    _n_met = ssp_obsmag_table_pergal.shape[1]
+    assert n_met == _n_met, msg.format(n_met, _n_met)
+
+    msg = "ssp_lg_age_gyr.shape[0]={0} must equal ssp_obsmag_table_pergal.shape[2]={1}"
+    _n_age = ssp_obsmag_table_pergal.shape[2]
+    assert n_age == _n_age, msg.format(n_age, _n_age)
+
+    n_met2, n_age2, n_rest_filters = ssp_restmag_table.shape
+    msg = "ssp_obsmag_table.shape[1]={0} must equal ssp_restmag_table.shape[0]={1}"
+    assert n_met == n_met2, msg.format(n_met, n_met2)
+
+    msg = "ssp_obsmag_table.shape[2]={0} must equal ssp_restmag_table.shape[1]={1}"
+    assert n_age == n_age2, msg.format(n_age, n_age2)
+
+    return ssp_obsmag_table_pergal

--- a/lsstdesc_diffsky/photometry/precompute_ssp_tables.py
+++ b/lsstdesc_diffsky/photometry/precompute_ssp_tables.py
@@ -1,6 +1,7 @@
 """
 """
 import numpy as np
+
 from . import photometry_interpolation_kernels as pik
 
 
@@ -43,6 +44,50 @@ def precompute_ssp_obsmags_on_z_table(
 
     """
     ssp_obsmag_table = pik._calc_obs_mag_vmap_f_ssp_z(
+        ssp_wave, ssp_fluxes, filter_waves, filter_trans, z_table, Om0, w0, wa, h
+    )
+    return ssp_obsmag_table
+
+
+def precompute_ssp_obsmags_on_z_table_singlemet(
+    ssp_wave,
+    ssp_fluxes,
+    filter_waves,
+    filter_trans,
+    z_table,
+    Om0,
+    w0,
+    wa,
+    h,
+):
+    """Precompute observed magnitudes of a collection of SEDs on a redshift grid
+
+    Parameters
+    ----------
+    ssp_wave : array of shape (n_spec, )
+
+    ssp_fluxes : array of shape (n_age, n_spec)
+
+    filter_waves : array of shape (n_filters, n_trans_curve)
+
+    filter_trans : array of shape (n_filters, n_trans_curve)
+
+    z_table : array of shape (n_redshift, )
+
+    Om0 : float
+
+    w0 : float
+
+    wa : float
+
+    h : float
+
+    Returns
+    -------
+    ssp_photmag_table : array of shape (n_redshift, n_age, n_filters)
+
+    """
+    ssp_obsmag_table = pik._calc_obs_mag_vmap_f_ssp_z_singlemet(
         ssp_wave, ssp_fluxes, filter_waves, filter_trans, z_table, Om0, w0, wa, h
     )
     return ssp_obsmag_table

--- a/lsstdesc_diffsky/photometry/precompute_ssp_tables.py
+++ b/lsstdesc_diffsky/photometry/precompute_ssp_tables.py
@@ -117,6 +117,30 @@ def precompute_ssp_restmags(ssp_wave, ssp_fluxes, filter_waves, filter_trans):
     return ssp_restmag_table
 
 
+def precompute_ssp_restmags_singlemet(ssp_wave, ssp_fluxes, filter_waves, filter_trans):
+    """Precompute restframe magnitudes of a collection of SEDs
+
+    Parameters
+    ----------
+    ssp_wave : array of shape (n_spec, )
+
+    ssp_fluxes : array of shape (n_age, n_spec)
+
+    filter_waves : array of shape (n_filters, n_trans_curve)
+
+    filter_trans : array of shape (n_filters, n_trans_curve)
+
+    Returns
+    -------
+    ssp_photmag_table : array of shape (n_age, n_filters)
+
+    """
+    ssp_restmag_table = pik._calc_rest_mag_vmap_f_ssp_singlemet(
+        ssp_wave, ssp_fluxes, filter_waves, filter_trans
+    )
+    return ssp_restmag_table
+
+
 def precompute_dust_attenuation(filter_waves, filter_trans, redshift, dust_params):
     """Precompute the attenuation of each galaxy in each band
 

--- a/lsstdesc_diffsky/photometry/tests/test_photometry_kernels.py
+++ b/lsstdesc_diffsky/photometry/tests/test_photometry_kernels.py
@@ -12,10 +12,14 @@ from jax import random as jran
 
 from ... import read_diffskypop_params
 from ...defaults import DEFAULT_DIFFGAL_PARAMS, OUTER_RIM_COSMO_PARAMS
+from ...legacy.roman_rubin_2023.dsps.data_loaders.retrieve_fake_fsps_data import (
+    load_fake_ssp_data_singlemet,
+)
 from ..photometry_kernels import calc_photometry_galpop
 from ..photometry_lc_interp import get_diffsky_sed_info
 from ..precompute_ssp_tables import (
     precompute_ssp_obsmags_on_z_table,
+    precompute_ssp_obsmags_on_z_table_singlemet,
     precompute_ssp_restmags,
 )
 
@@ -209,3 +213,67 @@ def test_precompute_photometry_correctly_handles_fb():
 
     # fb2 < fb so there galaxies should be fainter in cosmo2
     assert np.all(sed_info.gal_restmags_dust < sed_info2.gal_restmags_dust)
+
+
+def test_precompute_ssp_tables_agrees_with_and_without_metallicity_dimension():
+    n_gals = 3
+
+    ran_key = jran.PRNGKey(0)
+    z_obs_key, morphology_key = jran.split(ran_key, 2)
+    z_obs_galpop = jran.uniform(z_obs_key, minval=0.02, maxval=1, shape=(n_gals,))
+
+    DEFAULT_MAH_PARAMS, DEFAULT_MS_PARAMS, DEFAULT_Q_PARAMS = DEFAULT_DIFFGAL_PARAMS
+
+    mah_params_galpop = np.tile(DEFAULT_MAH_PARAMS, n_gals)
+    mah_params_galpop = mah_params_galpop.reshape((n_gals, -1))
+
+    ms_params_galpop = np.tile(DEFAULT_MS_PARAMS, n_gals)
+    ms_params_galpop = ms_params_galpop.reshape((n_gals, -1))
+
+    q_params_galpop = np.tile(DEFAULT_Q_PARAMS, n_gals)
+    q_params_galpop = q_params_galpop.reshape((n_gals, -1))
+
+    ssp_data = load_fake_ssp_data()
+    n_met, n_age, n_wave = ssp_data.ssp_flux.shape
+    ssp_data_singlemet = load_fake_ssp_data_singlemet()
+    ssp_data.ssp_flux[:, :, :] = ssp_data_singlemet.ssp_flux
+
+    diffskypop_params = read_diffskypop_params("roman_rubin_2023")
+
+    wave, u, g, r, i, z, y = load_fake_filter_transmission_curves()
+    rest_filter_waves = np.tile(wave, 2).reshape(2, (wave.size))
+    obs_filter_waves = np.tile(wave, 2).reshape(2, (wave.size))
+    rest_filter_trans = np.array((u, g))
+    obs_filter_trans = np.array((u, g))
+    n_obs_filters = rest_filter_waves.shape[0]
+
+    n_z_table = 51
+    ssp_z_table = np.linspace(
+        z_obs_galpop.min() / 2, z_obs_galpop.max() + 0.1, n_z_table
+    )
+
+    ssp_restmag_table = precompute_ssp_restmags(
+        ssp_data.ssp_wave, ssp_data.ssp_flux, rest_filter_waves, rest_filter_trans
+    )
+    ssp_obsmag_table = precompute_ssp_obsmags_on_z_table(
+        ssp_data.ssp_wave,
+        ssp_data.ssp_flux,
+        obs_filter_waves,
+        obs_filter_trans,
+        ssp_z_table,
+        *OUTER_RIM_COSMO_PARAMS[:-1],
+    )
+    assert ssp_obsmag_table.shape == (n_z_table, n_met, n_age, n_obs_filters)
+
+    ssp_obsmag_table_singlemet = precompute_ssp_obsmags_on_z_table_singlemet(
+        ssp_data.ssp_wave,
+        ssp_data_singlemet.ssp_flux,
+        obs_filter_waves,
+        obs_filter_trans,
+        ssp_z_table,
+        *OUTER_RIM_COSMO_PARAMS[:-1],
+    )
+    assert ssp_obsmag_table_singlemet.shape == (n_z_table, n_age, n_obs_filters)
+
+    for iz in range(n_met):
+        assert np.allclose(ssp_obsmag_table[:, iz, :, :], ssp_obsmag_table_singlemet)

--- a/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp.py
+++ b/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp.py
@@ -8,19 +8,13 @@ from diffsky.experimental.dspspop.burstshapepop import DEFAULT_BURSTSHAPE_U_PARA
 from diffsky.experimental.dspspop.dust_deltapop import DEFAULT_DUST_DELTA_U_PARAMS
 from diffsky.experimental.dspspop.lgavpop import DEFAULT_LGAV_U_PARAMS
 from diffsky.experimental.dspspop.lgfburstpop import DEFAULT_LGFBURST_U_PARAMS
-from diffstar.fitting_helpers.fitting_kernels import _integrate_sfr
 from dsps.experimental.diffburst import DLGAGE_MIN, LGAGE_MAX, LGYR_PEAK_MIN
 from dsps.metallicity.mzr import DEFAULT_MET_PDICT
-from jax import jit as jjit
 from jax import random as jran
-from jax import vmap
 
 from ...defaults import DEFAULT_DIFFGAL_PARAMS
 from ...disk_bulge_modeling.disk_knots import FKNOT_MAX
 from ..photometry_lc_interp import get_diffsky_sed_info
-
-_B = (0, None)
-_integrate_sfr_vmap = jjit(vmap(_integrate_sfr, in_axes=_B))
 
 DEFAULT_MET_PARAMS = np.array(list(DEFAULT_MET_PDICT.values()))
 
@@ -49,9 +43,6 @@ def test_get_diffsky_sed_info():
 
     Om0, w0, wa, h, fb = 0.3, -1, 0.0, 0.7, 0.16
     cosmo_params = np.array((Om0, w0, wa, h, fb))
-
-    # n_wave_seds = 300
-    # ssp_rest_seds = np.random.uniform(size=(n_met, n_age, n_wave_seds))
 
     n_rest_filters, n_obs_filters = 2, 3
     n_trans_wave = 40
@@ -109,7 +100,6 @@ def test_get_diffsky_sed_info():
         gal_frac_bulge_t_obs,
         gal_fbulge_params,
         gal_fknot,
-        # gal_rest_seds,
         gal_obsmags_nodust,
         gal_restmags_nodust,
         gal_obsmags_dust,
@@ -138,8 +128,6 @@ def test_get_diffsky_sed_info():
     assert gal_fknot.shape == (n_gals,)
     assert np.all(gal_fknot > 0)
     assert np.all(gal_fknot < FKNOT_MAX)
-
-    # assert gal_rest_seds.shape == (n_gals, n_wave_seds)
 
     assert gal_obsmags_nodust.shape == (n_gals, n_obs_filters)
     assert gal_restmags_nodust.shape == (n_gals, n_rest_filters)

--- a/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp_singlemet.py
+++ b/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp_singlemet.py
@@ -1,30 +1,27 @@
 """
 """
 import numpy as np
-from diffstar.fitting_helpers.fitting_kernels import _integrate_sfr
+from dsps.data_loaders.retrieve_fake_fsps_data import load_fake_ssp_data
 from dsps.experimental.diffburst import DLGAGE_MIN, LGAGE_MAX, LGYR_PEAK_MIN
 from dsps.metallicity.mzr import DEFAULT_MET_PDICT
-from jax import jit as jjit
 from jax import random as jran
-from jax import vmap
 
 from ... import read_diffskypop_params
 from ...defaults import DEFAULT_DIFFGAL_PARAMS
 from ...disk_bulge_modeling.disk_knots import FKNOT_MAX
 from ...legacy.roman_rubin_2023.dsps.data_loaders.retrieve_fake_fsps_data import (
+    SSPDataSingleMet,
     load_fake_ssp_data_singlemet,
 )
-from ..photometry_lc_interp_singlemet import get_diffsky_sed_info
-
-_B = (0, None)
-_integrate_sfr_vmap = jjit(vmap(_integrate_sfr, in_axes=_B))
+from ..photometry_lc_interp import get_diffsky_sed_info
+from ..photometry_lc_interp_singlemet import get_diffsky_sed_info_singlemet
 
 DEFAULT_MET_PARAMS = np.array(list(DEFAULT_MET_PDICT.values()))
 
 
-def test_get_diffsky_sed_info():
-    ssp_data = load_fake_ssp_data_singlemet()
-    n_age = ssp_data.ssp_lg_age_gyr.shape[0]
+def test_get_diffsky_sed_info_singlemet():
+    ssp_data_singlemet = load_fake_ssp_data_singlemet()
+    n_age = ssp_data_singlemet.ssp_lg_age_gyr.shape[0]
 
     n_t = 100
     gal_t_table = np.linspace(0.1, 13.8, n_t)
@@ -65,7 +62,7 @@ def test_get_diffsky_sed_info():
     diffskypop_params = read_diffskypop_params("roman_rubin_2023")
 
     ran_key = jran.PRNGKey(0)
-    _res = get_diffsky_sed_info(
+    _res = get_diffsky_sed_info_singlemet(
         ran_key,
         gal_z_obs,
         mah_params_galpop,
@@ -74,7 +71,7 @@ def test_get_diffsky_sed_info():
         ssp_z_table,
         ssp_restmag_table,
         ssp_obsmag_table,
-        ssp_data,
+        ssp_data_singlemet,
         gal_t_table,
         rest_filter_waves,
         rest_filter_trans,
@@ -97,7 +94,6 @@ def test_get_diffsky_sed_info():
         gal_frac_bulge_t_obs,
         gal_fbulge_params,
         gal_fknot,
-        # gal_rest_seds,
         gal_obsmags_nodust,
         gal_restmags_nodust,
         gal_obsmags_dust,
@@ -127,8 +123,6 @@ def test_get_diffsky_sed_info():
     assert np.all(gal_fknot > 0)
     assert np.all(gal_fknot < FKNOT_MAX)
 
-    # assert gal_rest_seds.shape == (n_gals, n_wave_seds)
-
     assert gal_obsmags_nodust.shape == (n_gals, n_obs_filters)
     assert gal_restmags_nodust.shape == (n_gals, n_rest_filters)
     assert gal_obsmags_dust.shape == (n_gals, n_obs_filters)
@@ -139,3 +133,143 @@ def test_get_diffsky_sed_info():
 
     assert np.all(gal_restmags_dust >= gal_restmags_nodust)
     assert np.any(gal_restmags_dust > gal_restmags_nodust)
+
+
+def test_get_diffsky_sed_info_singlemet_agrees_with_multimet():
+    ssp_data = load_fake_ssp_data()
+    n_met = ssp_data.ssp_lgmet.size
+    n_age = ssp_data.ssp_lg_age_gyr.size
+    ssp_data.ssp_flux[:, :, :] = ssp_data.ssp_flux[0, :, :]
+
+    n_t = 100
+    gal_t_table = np.linspace(0.1, 13.8, n_t)
+
+    n_gals = 150
+    gal_z_obs = np.random.uniform(0.01, 2.5, n_gals)
+
+    mah_params, ms_params, q_params = DEFAULT_DIFFGAL_PARAMS
+    mah_params_galpop = np.tile(mah_params, n_gals)
+    mah_params_galpop = mah_params_galpop.reshape((n_gals, -1))
+
+    ms_params_galpop = np.tile(ms_params, n_gals)
+    ms_params_galpop = ms_params_galpop.reshape((n_gals, -1))
+
+    q_params_galpop = np.tile(q_params, n_gals)
+    q_params_galpop = q_params_galpop.reshape((n_gals, -1))
+
+    Om0, w0, wa, h, fb = 0.3, -1, 0.0, 0.7, 0.16
+    cosmo_params = np.array((Om0, w0, wa, h, fb))
+
+    n_rest_filters, n_obs_filters = 2, 3
+    n_trans_wave = 40
+    obs_filter_waves = np.tile(
+        np.linspace(100, 5_000, n_trans_wave), n_obs_filters
+    ).reshape((n_obs_filters, n_trans_wave))
+    obs_filter_trans = np.ones_like(obs_filter_waves)
+
+    rest_filter_waves = np.tile(
+        np.linspace(100, 5_000, n_trans_wave), n_rest_filters
+    ).reshape((n_rest_filters, n_trans_wave))
+    rest_filter_trans = np.ones_like(rest_filter_waves)
+
+    n_z_table = 23
+    ssp_z_table = np.linspace(0.001, 10, n_z_table)
+    ssp_restmag_table = np.random.uniform(size=(n_met, n_age, n_rest_filters))
+    ssp_obsmag_table = np.random.uniform(size=(n_z_table, n_met, n_age, n_obs_filters))
+
+    for iz in range(n_met):
+        ssp_restmag_table[iz, :, :] = ssp_restmag_table[0, :, :]
+        ssp_obsmag_table[:, iz, :, :] = ssp_obsmag_table[:, 0, :, :]
+
+    diffskypop_params = read_diffskypop_params("roman_rubin_2023")
+    ran_key = jran.PRNGKey(0)
+    _res = get_diffsky_sed_info(
+        ran_key,
+        gal_z_obs,
+        mah_params_galpop,
+        ms_params_galpop,
+        q_params_galpop,
+        ssp_z_table,
+        ssp_restmag_table,
+        ssp_obsmag_table,
+        ssp_data.ssp_lgmet,
+        ssp_data.ssp_lg_age_gyr,
+        gal_t_table,
+        rest_filter_waves,
+        rest_filter_trans,
+        obs_filter_waves,
+        obs_filter_trans,
+        diffskypop_params.lgfburst_u_params,
+        diffskypop_params.burstshape_u_params,
+        diffskypop_params.lgav_dust_u_params,
+        diffskypop_params.delta_dust_u_params,
+        diffskypop_params.funo_dust_u_params,
+        diffskypop_params.lgmet_params,
+        cosmo_params,
+    )
+    for x in _res:
+        assert np.all(np.isfinite(x))
+
+    (
+        weights,
+        gal_frac_trans_obs,
+        gal_frac_trans_rest,
+        gal_att_curve_params,
+        gal_frac_unobs,
+        gal_fburst,
+        gal_burstshape_params,
+        gal_frac_bulge_t_obs,
+        gal_fbulge_params,
+        gal_fknot,
+        # gal_rest_seds,
+        gal_obsmags_nodust,
+        gal_restmags_nodust,
+        gal_obsmags_dust,
+        gal_restmags_dust,
+    ) = _res
+
+    ssp_restmag_table_singlemet = ssp_restmag_table[0, :, :]
+    ssp_obsmag_table_singlemet = ssp_obsmag_table[:, 0, :, :]
+
+    ssp_data_singlemet = SSPDataSingleMet(
+        ssp_data.ssp_lg_age_gyr, ssp_data.ssp_wave, ssp_data.ssp_flux[0, :, :]
+    )
+    _res = get_diffsky_sed_info_singlemet(
+        ran_key,
+        gal_z_obs,
+        mah_params_galpop,
+        ms_params_galpop,
+        q_params_galpop,
+        ssp_z_table,
+        ssp_restmag_table_singlemet,
+        ssp_obsmag_table_singlemet,
+        ssp_data_singlemet,
+        gal_t_table,
+        rest_filter_waves,
+        rest_filter_trans,
+        obs_filter_waves,
+        obs_filter_trans,
+        diffskypop_params,
+        cosmo_params,
+    )
+    (
+        weights_singlemet,
+        gal_frac_trans_obs_singlemet,
+        gal_frac_trans_rest_singlemet,
+        gal_att_curve_params_singlemet,
+        gal_frac_unobs_singlemet,
+        gal_fburst_singlemet,
+        gal_burstshape_params_singlemet,
+        gal_frac_bulge_t_obs_singlemet,
+        gal_fbulge_params_singlemet,
+        gal_fknot_singlemet,
+        gal_obsmags_nodust_singlemet,
+        gal_restmags_nodust_singlemet,
+        gal_obsmags_dust_singlemet,
+        gal_restmags_dust_singlemet,
+    ) = _res
+
+    assert np.allclose(gal_restmags_dust, gal_restmags_dust_singlemet, rtol=1e-4)
+    assert np.allclose(gal_obsmags_dust, gal_obsmags_dust_singlemet, rtol=1e-4)
+    assert np.allclose(gal_restmags_nodust, gal_restmags_nodust_singlemet, rtol=1e-4)
+    assert np.allclose(gal_obsmags_nodust, gal_obsmags_nodust_singlemet, rtol=1e-4)

--- a/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp_singlemet.py
+++ b/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp_singlemet.py
@@ -17,6 +17,9 @@ from jax import vmap
 
 from ...defaults import DEFAULT_DIFFGAL_PARAMS
 from ...disk_bulge_modeling.disk_knots import FKNOT_MAX
+from ...legacy.roman_rubin_2023.dsps.data_loaders.retrieve_fake_fsps_data import (
+    load_fake_ssp_data,
+)
 from ..photometry_lc_interp_singlemet import get_diffsky_sed_info
 
 _B = (0, None)
@@ -26,10 +29,9 @@ DEFAULT_MET_PARAMS = np.array(list(DEFAULT_MET_PDICT.values()))
 
 
 def test_get_diffsky_sed_info():
-    n_met, n_age = 12, 40
-
-    ssp_lgmet = np.linspace(-3, -1, n_met)
-    ssp_lg_age_gyr = np.linspace(5, 10.25, n_age) - 9.0
+    ssp_data = load_fake_ssp_data()
+    n_met = ssp_data.ssp_lgmet.shape[0]
+    n_age = ssp_data.ssp_lg_age_gyr.shape[0]
 
     n_t = 100
     gal_t_table = np.linspace(0.1, 13.8, n_t)
@@ -49,9 +51,6 @@ def test_get_diffsky_sed_info():
 
     Om0, w0, wa, h, fb = 0.3, -1, 0.0, 0.7, 0.16
     cosmo_params = np.array((Om0, w0, wa, h, fb))
-
-    # n_wave_seds = 300
-    # ssp_rest_seds = np.random.uniform(size=(n_met, n_age, n_wave_seds))
 
     n_rest_filters, n_obs_filters = 2, 3
     n_trans_wave = 40
@@ -80,8 +79,7 @@ def test_get_diffsky_sed_info():
         ssp_z_table,
         ssp_restmag_table,
         ssp_obsmag_table,
-        ssp_lgmet,
-        ssp_lg_age_gyr,
+        ssp_data,
         gal_t_table,
         rest_filter_waves,
         rest_filter_trans,

--- a/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp_singlemet.py
+++ b/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp_singlemet.py
@@ -1,13 +1,6 @@
 """
 """
 import numpy as np
-from diffsky.experimental.dspspop.boris_dust import (
-    DEFAULT_U_PARAMS as DEFAULT_FUNO_U_PARAMS,
-)
-from diffsky.experimental.dspspop.burstshapepop import DEFAULT_BURSTSHAPE_U_PARAMS
-from diffsky.experimental.dspspop.dust_deltapop import DEFAULT_DUST_DELTA_U_PARAMS
-from diffsky.experimental.dspspop.lgavpop import DEFAULT_LGAV_U_PARAMS
-from diffsky.experimental.dspspop.lgfburstpop import DEFAULT_LGFBURST_U_PARAMS
 from diffstar.fitting_helpers.fitting_kernels import _integrate_sfr
 from dsps.experimental.diffburst import DLGAGE_MIN, LGAGE_MAX, LGYR_PEAK_MIN
 from dsps.metallicity.mzr import DEFAULT_MET_PDICT
@@ -15,6 +8,7 @@ from jax import jit as jjit
 from jax import random as jran
 from jax import vmap
 
+from ... import read_diffskypop_params
 from ...defaults import DEFAULT_DIFFGAL_PARAMS
 from ...disk_bulge_modeling.disk_knots import FKNOT_MAX
 from ...legacy.roman_rubin_2023.dsps.data_loaders.retrieve_fake_fsps_data import (
@@ -69,6 +63,8 @@ def test_get_diffsky_sed_info():
     ssp_restmag_table = np.random.uniform(size=(n_met, n_age, n_rest_filters))
     ssp_obsmag_table = np.random.uniform(size=(n_z_table, n_met, n_age, n_obs_filters))
 
+    diffskypop_params = read_diffskypop_params("roman_rubin_2023")
+
     ran_key = jran.PRNGKey(0)
     _res = get_diffsky_sed_info(
         ran_key,
@@ -85,12 +81,7 @@ def test_get_diffsky_sed_info():
         rest_filter_trans,
         obs_filter_waves,
         obs_filter_trans,
-        DEFAULT_LGFBURST_U_PARAMS,
-        DEFAULT_BURSTSHAPE_U_PARAMS,
-        DEFAULT_LGAV_U_PARAMS,
-        DEFAULT_DUST_DELTA_U_PARAMS,
-        DEFAULT_FUNO_U_PARAMS,
-        DEFAULT_MET_PARAMS,
+        diffskypop_params,
         cosmo_params,
     )
     for x in _res:

--- a/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp_singlemet.py
+++ b/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp_singlemet.py
@@ -1,0 +1,153 @@
+"""
+"""
+import numpy as np
+from diffsky.experimental.dspspop.boris_dust import (
+    DEFAULT_U_PARAMS as DEFAULT_FUNO_U_PARAMS,
+)
+from diffsky.experimental.dspspop.burstshapepop import DEFAULT_BURSTSHAPE_U_PARAMS
+from diffsky.experimental.dspspop.dust_deltapop import DEFAULT_DUST_DELTA_U_PARAMS
+from diffsky.experimental.dspspop.lgavpop import DEFAULT_LGAV_U_PARAMS
+from diffsky.experimental.dspspop.lgfburstpop import DEFAULT_LGFBURST_U_PARAMS
+from diffstar.fitting_helpers.fitting_kernels import _integrate_sfr
+from dsps.experimental.diffburst import DLGAGE_MIN, LGAGE_MAX, LGYR_PEAK_MIN
+from dsps.metallicity.mzr import DEFAULT_MET_PDICT
+from jax import jit as jjit
+from jax import random as jran
+from jax import vmap
+
+from ...defaults import DEFAULT_DIFFGAL_PARAMS
+from ...disk_bulge_modeling.disk_knots import FKNOT_MAX
+from ..photometry_lc_interp_singlemet import get_diffsky_sed_info
+
+_B = (0, None)
+_integrate_sfr_vmap = jjit(vmap(_integrate_sfr, in_axes=_B))
+
+DEFAULT_MET_PARAMS = np.array(list(DEFAULT_MET_PDICT.values()))
+
+
+def test_get_diffsky_sed_info():
+    n_met, n_age = 12, 40
+
+    ssp_lgmet = np.linspace(-3, -1, n_met)
+    ssp_lg_age_gyr = np.linspace(5, 10.25, n_age) - 9.0
+
+    n_t = 100
+    gal_t_table = np.linspace(0.1, 13.8, n_t)
+
+    n_gals = 150
+    gal_z_obs = np.random.uniform(0.01, 2.5, n_gals)
+
+    mah_params, ms_params, q_params = DEFAULT_DIFFGAL_PARAMS
+    mah_params_galpop = np.tile(mah_params, n_gals)
+    mah_params_galpop = mah_params_galpop.reshape((n_gals, -1))
+
+    ms_params_galpop = np.tile(ms_params, n_gals)
+    ms_params_galpop = ms_params_galpop.reshape((n_gals, -1))
+
+    q_params_galpop = np.tile(q_params, n_gals)
+    q_params_galpop = q_params_galpop.reshape((n_gals, -1))
+
+    Om0, w0, wa, h, fb = 0.3, -1, 0.0, 0.7, 0.16
+    cosmo_params = np.array((Om0, w0, wa, h, fb))
+
+    # n_wave_seds = 300
+    # ssp_rest_seds = np.random.uniform(size=(n_met, n_age, n_wave_seds))
+
+    n_rest_filters, n_obs_filters = 2, 3
+    n_trans_wave = 40
+    obs_filter_waves = np.tile(
+        np.linspace(100, 5_000, n_trans_wave), n_obs_filters
+    ).reshape((n_obs_filters, n_trans_wave))
+    obs_filter_trans = np.ones_like(obs_filter_waves)
+
+    rest_filter_waves = np.tile(
+        np.linspace(100, 5_000, n_trans_wave), n_rest_filters
+    ).reshape((n_rest_filters, n_trans_wave))
+    rest_filter_trans = np.ones_like(rest_filter_waves)
+
+    n_z_table = 23
+    ssp_z_table = np.linspace(0.001, 10, n_z_table)
+    ssp_restmag_table = np.random.uniform(size=(n_met, n_age, n_rest_filters))
+    ssp_obsmag_table = np.random.uniform(size=(n_z_table, n_met, n_age, n_obs_filters))
+
+    ran_key = jran.PRNGKey(0)
+    _res = get_diffsky_sed_info(
+        ran_key,
+        gal_z_obs,
+        mah_params_galpop,
+        ms_params_galpop,
+        q_params_galpop,
+        ssp_z_table,
+        ssp_restmag_table,
+        ssp_obsmag_table,
+        ssp_lgmet,
+        ssp_lg_age_gyr,
+        gal_t_table,
+        rest_filter_waves,
+        rest_filter_trans,
+        obs_filter_waves,
+        obs_filter_trans,
+        DEFAULT_LGFBURST_U_PARAMS,
+        DEFAULT_BURSTSHAPE_U_PARAMS,
+        DEFAULT_LGAV_U_PARAMS,
+        DEFAULT_DUST_DELTA_U_PARAMS,
+        DEFAULT_FUNO_U_PARAMS,
+        DEFAULT_MET_PARAMS,
+        cosmo_params,
+    )
+    for x in _res:
+        assert np.all(np.isfinite(x))
+
+    (
+        weights,
+        gal_frac_trans_obs,
+        gal_frac_trans_rest,
+        gal_att_curve_params,
+        gal_frac_unobs,
+        gal_fburst,
+        gal_burstshape_params,
+        gal_frac_bulge_t_obs,
+        gal_fbulge_params,
+        gal_fknot,
+        # gal_rest_seds,
+        gal_obsmags_nodust,
+        gal_restmags_nodust,
+        gal_obsmags_dust,
+        gal_restmags_dust,
+    ) = _res
+    assert weights.shape == (n_gals, n_met, n_age)
+    assert gal_frac_trans_obs.shape == (n_gals, n_age, n_obs_filters)
+    assert gal_frac_trans_rest.shape == (n_gals, n_age, n_rest_filters)
+    assert gal_att_curve_params.shape == (n_gals, 3)
+    assert gal_frac_unobs.shape == (n_gals, n_age)
+
+    assert gal_fburst.shape == (n_gals,)
+    assert gal_burstshape_params.shape == (n_gals, 2)
+    assert np.all(gal_fburst > 0)
+    assert np.all(gal_fburst < 0.1)
+    lgyr_peak = gal_burstshape_params[:, 0]
+    lgyr_max = gal_burstshape_params[:, 1]
+    assert np.all(lgyr_peak > LGYR_PEAK_MIN)
+    assert np.all(lgyr_max > lgyr_peak + DLGAGE_MIN)
+    assert np.all(lgyr_max < LGAGE_MAX)
+
+    assert gal_frac_bulge_t_obs.shape == (n_gals,)
+    assert np.all(gal_frac_bulge_t_obs > 0)
+    assert np.all(gal_frac_bulge_t_obs < 1)
+    assert gal_fbulge_params.shape == (n_gals, 3)
+    assert gal_fknot.shape == (n_gals,)
+    assert np.all(gal_fknot > 0)
+    assert np.all(gal_fknot < FKNOT_MAX)
+
+    # assert gal_rest_seds.shape == (n_gals, n_wave_seds)
+
+    assert gal_obsmags_nodust.shape == (n_gals, n_obs_filters)
+    assert gal_restmags_nodust.shape == (n_gals, n_rest_filters)
+    assert gal_obsmags_dust.shape == (n_gals, n_obs_filters)
+    assert gal_restmags_dust.shape == (n_gals, n_rest_filters)
+
+    assert np.all(gal_obsmags_dust >= gal_obsmags_nodust)
+    assert np.any(gal_obsmags_dust > gal_obsmags_nodust)
+
+    assert np.all(gal_restmags_dust >= gal_restmags_nodust)
+    assert np.any(gal_restmags_dust > gal_restmags_nodust)

--- a/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp_singlemet.py
+++ b/lsstdesc_diffsky/photometry/tests/test_photometry_lc_interp_singlemet.py
@@ -12,7 +12,7 @@ from ... import read_diffskypop_params
 from ...defaults import DEFAULT_DIFFGAL_PARAMS
 from ...disk_bulge_modeling.disk_knots import FKNOT_MAX
 from ...legacy.roman_rubin_2023.dsps.data_loaders.retrieve_fake_fsps_data import (
-    load_fake_ssp_data,
+    load_fake_ssp_data_singlemet,
 )
 from ..photometry_lc_interp_singlemet import get_diffsky_sed_info
 
@@ -23,8 +23,7 @@ DEFAULT_MET_PARAMS = np.array(list(DEFAULT_MET_PDICT.values()))
 
 
 def test_get_diffsky_sed_info():
-    ssp_data = load_fake_ssp_data()
-    n_met = ssp_data.ssp_lgmet.shape[0]
+    ssp_data = load_fake_ssp_data_singlemet()
     n_age = ssp_data.ssp_lg_age_gyr.shape[0]
 
     n_t = 100
@@ -60,8 +59,8 @@ def test_get_diffsky_sed_info():
 
     n_z_table = 23
     ssp_z_table = np.linspace(0.001, 10, n_z_table)
-    ssp_restmag_table = np.random.uniform(size=(n_met, n_age, n_rest_filters))
-    ssp_obsmag_table = np.random.uniform(size=(n_z_table, n_met, n_age, n_obs_filters))
+    ssp_restmag_table = np.random.uniform(size=(n_age, n_rest_filters))
+    ssp_obsmag_table = np.random.uniform(size=(n_z_table, n_age, n_obs_filters))
 
     diffskypop_params = read_diffskypop_params("roman_rubin_2023")
 
@@ -104,7 +103,7 @@ def test_get_diffsky_sed_info():
         gal_obsmags_dust,
         gal_restmags_dust,
     ) = _res
-    assert weights.shape == (n_gals, n_met, n_age)
+    assert weights.shape == (n_gals, n_age)
     assert gal_frac_trans_obs.shape == (n_gals, n_age, n_obs_filters)
     assert gal_frac_trans_rest.shape == (n_gals, n_age, n_rest_filters)
     assert gal_att_curve_params.shape == (n_gals, 3)

--- a/lsstdesc_diffsky/sed/disk_bulge_sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/disk_bulge_sed_kernels_singlemet.py
@@ -1,0 +1,231 @@
+"""
+"""
+import typing
+
+from diffsky.experimental.dspspop.boris_dust import _get_funo_from_u_params_singlegal
+from diffsky.experimental.dspspop.burstshapepop import (
+    _get_burstshape_galpop_from_params,
+)
+from diffsky.experimental.dspspop.dust_deltapop import (
+    _get_dust_delta_galpop_from_u_params,
+)
+from diffsky.experimental.dspspop.lgavpop import _get_lgav_galpop_from_u_params
+from diffsky.experimental.dspspop.lgfburstpop import _get_lgfburst_galpop_from_u_params
+from diffstar import sfh_singlegal
+from dsps.constants import N_T_LGSM_INTEGRATION, T_BIRTH_MIN
+from dsps.cosmology.flat_wcdm import _age_at_z_kern, age_at_z0
+from dsps.dust.att_curves import (
+    UV_BUMP_DW,
+    UV_BUMP_W0,
+    _frac_transmission_from_k_lambda,
+    _get_eb_from_delta,
+    sbl18_k_lambda,
+)
+from dsps.experimental.diffburst import (
+    _age_weights_from_params as _burst_age_weights_from_params,
+)
+from dsps.experimental.diffburst import (
+    _get_params_from_u_params as _get_diffburst_params_from_u_params,
+)
+from dsps.sed.metallicity_weights import calc_lgmet_weights_from_lognormal_mdf
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import vmap
+
+from ..defaults import DEFAULT_COSMO_PARAMS
+from ..disk_bulge_modeling.disk_bulge_kernels import (
+    _decompose_sfh_singlegal_into_bulge_disk_knots,
+)
+from .sed_kernels import _get_galprops_at_t_obs_singlegal
+
+_T = (None, None, 0)
+_frac_transmission_from_k_lambda_age_vmap = jjit(
+    vmap(_frac_transmission_from_k_lambda, in_axes=_T)
+)
+
+
+class DiffskySEDInfo(typing.NamedTuple):
+    """NamedTuple with info about SSPs, filter data and cosmology"""
+
+    rest_sed_bulge: jnp.ndarray
+    rest_sed_diffuse_disk: jnp.ndarray
+    rest_sed_knot: jnp.ndarray
+    rest_sed_bulge_nodust: jnp.ndarray
+    rest_sed_diffuse_disk_nodust: jnp.ndarray
+    rest_sed_knot_nodust: jnp.ndarray
+    mstar_bulge: jnp.ndarray
+    mstar_diffuse_disk: jnp.ndarray
+    mstar_knot: jnp.ndarray
+    mstar_burst: jnp.ndarray
+    mstar_total: jnp.ndarray
+
+
+def calc_rest_sed_disk_bulge_knot_singlegal(
+    z_obs,
+    diffmah_params,
+    diffstar_ms_params,
+    diffstar_q_params,
+    fbulge_params,
+    fknot,
+    ssp_lgmet,
+    ssp_lg_age_gyr,
+    ssp_wave_ang,
+    ssp_flux,
+    lgfburst_pop_u_params,
+    burstshapepop_u_params,
+    lgav_pop_u_params,
+    dust_delta_pop_u_params,
+    fracuno_pop_u_params,
+    met_params,
+    cosmo_params=DEFAULT_COSMO_PARAMS,
+):
+    Om0, w0, wa, h, fb = cosmo_params
+    t0 = age_at_z0(Om0, w0, wa, h)
+    t_table = jnp.linspace(2 * T_BIRTH_MIN, t0, N_T_LGSM_INTEGRATION)
+    lgt0 = jnp.log10(t0)
+    t_obs = _age_at_z_kern(z_obs, Om0, w0, wa, h)
+    sfh_table = sfh_singlegal(
+        t_table,
+        diffmah_params,
+        diffstar_ms_params,
+        diffstar_q_params,
+        lgt0=lgt0,
+        fb=fb,
+    )
+
+    mzr_params, lgmet_scatter = met_params[:-1], met_params[-1]
+    _galprops_at_t_obs = _get_galprops_at_t_obs_singlegal(
+        t_obs, t_table, sfh_table, mzr_params, ssp_lg_age_gyr
+    )
+    logsm_t_obs, logssfr_t_obs, lgmet_t_obs, smooth_age_weights = _galprops_at_t_obs[:4]
+    mstar_total = 10**logsm_t_obs
+
+    lgmet_weights = calc_lgmet_weights_from_lognormal_mdf(
+        lgmet_t_obs, lgmet_scatter, ssp_lgmet
+    )
+
+    # Compute burst fraction and burst shape
+    lgfburst = _get_lgfburst_galpop_from_u_params(
+        logsm_t_obs, logssfr_t_obs, lgfburst_pop_u_params
+    )
+    fburst = 10**lgfburst
+
+    diffburst_u_params = _get_burstshape_galpop_from_params(
+        logsm_t_obs, logssfr_t_obs, burstshapepop_u_params
+    )
+    burstshape_params = jnp.array(
+        _get_diffburst_params_from_u_params(diffburst_u_params)
+    )
+    ssp_lg_age_yr = ssp_lg_age_gyr + 9
+    age_weights_singleburst = _burst_age_weights_from_params(
+        ssp_lg_age_yr, burstshape_params
+    )
+
+    # Decompose SFH into disk/bulge/knots
+    _res = _decompose_sfh_singlegal_into_bulge_disk_knots(
+        fbulge_params,
+        fknot,
+        t_obs,
+        t_table,
+        sfh_table,
+        fburst,
+        age_weights_singleburst,
+        ssp_lg_age_gyr,
+    )
+    mbulge, mdd, mknot, mburst = _res[:4]
+    bulge_age_weights, dd_age_weights, knot_age_weights = _res[4:7]
+
+    # Compute SED of each component, neglecting dust attenuation
+    n_met, n_age, n_wave = ssp_flux.shape
+    lgmet_weights = lgmet_weights.reshape((n_met, 1, 1))
+    bulge_weights = lgmet_weights * bulge_age_weights.reshape((1, n_age, 1))
+    dd_weights = lgmet_weights * dd_age_weights.reshape((1, n_age, 1))
+    knot_weights = lgmet_weights * knot_age_weights.reshape((1, n_age, 1))
+
+    rest_sed_bulge_nodust = jnp.sum(bulge_weights * ssp_flux, axis=(0, 1)) * mbulge
+    rest_sed_dd_nodust = jnp.sum(dd_weights * ssp_flux, axis=(0, 1)) * mdd
+    rest_sed_knot_nodust = jnp.sum(knot_weights * ssp_flux, axis=(0, 1)) * mknot
+
+    # Compute transmission curve (assumed same for all components)
+    lgav = _get_lgav_galpop_from_u_params(logsm_t_obs, logssfr_t_obs, lgav_pop_u_params)
+    dust_delta = _get_dust_delta_galpop_from_u_params(
+        logsm_t_obs, logssfr_t_obs, dust_delta_pop_u_params
+    )
+    frac_unobscured = _get_funo_from_u_params_singlegal(
+        logsm_t_obs, lgfburst, logssfr_t_obs, ssp_lg_age_gyr, fracuno_pop_u_params
+    )
+
+    ssp_wave_micron = ssp_wave_ang / 1e4
+    dust_Av = 10**lgav
+    dust_Eb = _get_eb_from_delta(dust_delta)
+    k_lambda = sbl18_k_lambda(
+        ssp_wave_micron, UV_BUMP_W0, UV_BUMP_DW, dust_Eb, dust_delta
+    )
+    frac_dust_trans = _frac_transmission_from_k_lambda_age_vmap(
+        k_lambda, dust_Av, frac_unobscured
+    )
+    frac_dust_trans = frac_dust_trans.reshape((1, n_age, n_wave))
+
+    rest_sed_bulge = (
+        jnp.sum(bulge_weights * ssp_flux * frac_dust_trans, axis=(0, 1)) * mbulge
+    )
+
+    rest_sed_dd = jnp.sum(dd_weights * ssp_flux * frac_dust_trans, axis=(0, 1)) * mdd
+    rest_sed_knot = (
+        jnp.sum(knot_weights * ssp_flux * frac_dust_trans, axis=(0, 1)) * mknot
+    )
+
+    rest_seds = rest_sed_bulge, rest_sed_dd, rest_sed_knot
+    rest_seds_nodust = rest_sed_bulge_nodust, rest_sed_dd_nodust, rest_sed_knot_nodust
+    masses = mbulge, mdd, mknot, mburst, mstar_total
+
+    ret = (*rest_seds, *rest_seds_nodust, *masses)
+    return DiffskySEDInfo(*ret)
+
+
+_DBK = (*[0] * 6, *[None] * 11)
+_calc_rest_sed_disk_bulge_knot_vmap = jjit(
+    vmap(calc_rest_sed_disk_bulge_knot_singlegal, in_axes=_DBK)
+)
+
+
+def calc_rest_sed_disk_bulge_knot_galpop(
+    z_obs,
+    diffmah_params,
+    diffstar_ms_params,
+    diffstar_q_params,
+    fbulge_params,
+    fknot,
+    ssp_lgmet,
+    ssp_lg_age_gyr,
+    ssp_wave_ang,
+    ssp_flux,
+    lgfburst_pop_u_params,
+    burstshapepop_u_params,
+    lgav_pop_u_params,
+    dust_delta_pop_u_params,
+    fracuno_pop_u_params,
+    met_params,
+    cosmo_params=DEFAULT_COSMO_PARAMS,
+):
+    return DiffskySEDInfo(
+        *_calc_rest_sed_disk_bulge_knot_vmap(
+            z_obs,
+            diffmah_params,
+            diffstar_ms_params,
+            diffstar_q_params,
+            fbulge_params,
+            fknot,
+            ssp_lgmet,
+            ssp_lg_age_gyr,
+            ssp_wave_ang,
+            ssp_flux,
+            lgfburst_pop_u_params,
+            burstshapepop_u_params,
+            lgav_pop_u_params,
+            dust_delta_pop_u_params,
+            fracuno_pop_u_params,
+            met_params,
+            cosmo_params,
+        )
+    )

--- a/lsstdesc_diffsky/sed/disk_bulge_sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/disk_bulge_sed_kernels_singlemet.py
@@ -2,15 +2,6 @@
 """
 import typing
 
-from diffsky.experimental.dspspop.boris_dust import _get_funo_from_u_params_singlegal
-from diffsky.experimental.dspspop.burstshapepop import (
-    _get_burstshape_galpop_from_params,
-)
-from diffsky.experimental.dspspop.dust_deltapop import (
-    _get_dust_delta_galpop_from_u_params,
-)
-from diffsky.experimental.dspspop.lgavpop import _get_lgav_galpop_from_u_params
-from diffsky.experimental.dspspop.lgfburstpop import _get_lgfburst_galpop_from_u_params
 from diffstar import sfh_singlegal
 from dsps.constants import N_T_LGSM_INTEGRATION, T_BIRTH_MIN
 from dsps.cosmology.flat_wcdm import _age_at_z_kern, age_at_z0
@@ -35,6 +26,11 @@ from ..defaults import DEFAULT_COSMO_PARAMS
 from ..disk_bulge_modeling.disk_bulge_kernels import (
     _decompose_sfh_singlegal_into_bulge_disk_knots,
 )
+from ..dspspop.boris_dust import _get_funo_from_u_params_singlegal
+from ..dspspop.burstshapepop import _get_burstshape_galpop_from_params
+from ..dspspop.dust_deltapop import _get_dust_delta_galpop_from_u_params
+from ..dspspop.lgavpop import _get_lgav_galpop_from_u_params
+from ..dspspop.lgfburstpop import _get_lgfburst_galpop_from_u_params
 from .sed_kernels_singlemet import _get_galprops_at_t_obs_singlegal
 
 _T = (None, None, 0)

--- a/lsstdesc_diffsky/sed/disk_bulge_sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/disk_bulge_sed_kernels_singlemet.py
@@ -67,11 +67,7 @@ def calc_rest_sed_disk_bulge_knot_singlegal(
     fbulge_params,
     fknot,
     ssp_data,
-    lgfburst_pop_u_params,
-    burstshapepop_u_params,
-    lgav_pop_u_params,
-    dust_delta_pop_u_params,
-    fracuno_pop_u_params,
+    diffskypop_params,
     cosmo_params=DEFAULT_COSMO_PARAMS,
 ):
     Om0, w0, wa, h, fb = cosmo_params
@@ -96,12 +92,12 @@ def calc_rest_sed_disk_bulge_knot_singlegal(
 
     # Compute burst fraction and burst shape
     lgfburst = _get_lgfburst_galpop_from_u_params(
-        logsm_t_obs, logssfr_t_obs, lgfburst_pop_u_params
+        logsm_t_obs, logssfr_t_obs, diffskypop_params.lgfburst_u_params
     )
     fburst = 10**lgfburst
 
     diffburst_u_params = _get_burstshape_galpop_from_params(
-        logsm_t_obs, logssfr_t_obs, burstshapepop_u_params
+        logsm_t_obs, logssfr_t_obs, diffskypop_params.burstshape_u_params
     )
     burstshape_params = jnp.array(
         _get_diffburst_params_from_u_params(diffburst_u_params)
@@ -138,16 +134,18 @@ def calc_rest_sed_disk_bulge_knot_singlegal(
     rest_sed_knot_nodust = jnp.sum(knot_weights * ssp_data.ssp_flux, axis=(0,)) * mknot
 
     # Compute transmission curve (assumed same for all components)
-    lgav = _get_lgav_galpop_from_u_params(logsm_t_obs, logssfr_t_obs, lgav_pop_u_params)
+    lgav = _get_lgav_galpop_from_u_params(
+        logsm_t_obs, logssfr_t_obs, diffskypop_params.lgav_dust_u_params
+    )
     dust_delta = _get_dust_delta_galpop_from_u_params(
-        logsm_t_obs, logssfr_t_obs, dust_delta_pop_u_params
+        logsm_t_obs, logssfr_t_obs, diffskypop_params.delta_dust_u_params
     )
     frac_unobscured = _get_funo_from_u_params_singlegal(
         logsm_t_obs,
         lgfburst,
         logssfr_t_obs,
         ssp_data.ssp_lg_age_gyr,
-        fracuno_pop_u_params,
+        diffskypop_params.funo_dust_u_params,
     )
 
     ssp_wave_micron = ssp_data.ssp_wave / 1e4
@@ -180,7 +178,7 @@ def calc_rest_sed_disk_bulge_knot_singlegal(
     return DiffskySEDInfo(*ret)
 
 
-_DBK = (*[0] * 6, *[None] * 7)
+_DBK = (*[0] * 6, *[None] * 3)
 _calc_rest_sed_disk_bulge_knot_vmap = jjit(
     vmap(calc_rest_sed_disk_bulge_knot_singlegal, in_axes=_DBK)
 )
@@ -194,11 +192,7 @@ def calc_rest_sed_disk_bulge_knot_galpop(
     fbulge_params,
     fknot,
     ssp_data,
-    lgfburst_pop_u_params,
-    burstshapepop_u_params,
-    lgav_pop_u_params,
-    dust_delta_pop_u_params,
-    fracuno_pop_u_params,
+    diffskypop_params,
     cosmo_params=DEFAULT_COSMO_PARAMS,
 ):
     return DiffskySEDInfo(
@@ -210,11 +204,7 @@ def calc_rest_sed_disk_bulge_knot_galpop(
             fbulge_params,
             fknot,
             ssp_data,
-            lgfburst_pop_u_params,
-            burstshapepop_u_params,
-            lgav_pop_u_params,
-            dust_delta_pop_u_params,
-            fracuno_pop_u_params,
+            diffskypop_params,
             cosmo_params,
         )
     )

--- a/lsstdesc_diffsky/sed/sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/sed_kernels_singlemet.py
@@ -1,14 +1,5 @@
 """
 """
-from diffsky.experimental.dspspop.boris_dust import _get_funo_from_u_params_singlegal
-from diffsky.experimental.dspspop.burstshapepop import (
-    _get_burstshape_galpop_from_params,
-)
-from diffsky.experimental.dspspop.dust_deltapop import (
-    _get_dust_delta_galpop_from_u_params,
-)
-from diffsky.experimental.dspspop.lgavpop import _get_lgav_galpop_from_u_params
-from diffsky.experimental.dspspop.lgfburstpop import _get_lgfburst_galpop_from_u_params
 from diffstar import sfh_singlegal
 from dsps.constants import N_T_LGSM_INTEGRATION, T_BIRTH_MIN
 from dsps.cosmology.flat_wcdm import _age_at_z_kern, age_at_z0
@@ -29,6 +20,11 @@ from jax import numpy as jnp
 from jax import vmap
 
 from ..defaults import DEFAULT_COSMO_PARAMS
+from ..dspspop.boris_dust import _get_funo_from_u_params_singlegal
+from ..dspspop.burstshapepop import _get_burstshape_galpop_from_params
+from ..dspspop.dust_deltapop import _get_dust_delta_galpop_from_u_params
+from ..dspspop.lgavpop import _get_lgav_galpop_from_u_params
+from ..dspspop.lgfburstpop import _get_lgfburst_galpop_from_u_params
 
 _T = (None, None, 0)
 _frac_transmission_from_k_lambda_age_vmap = jjit(
@@ -79,27 +75,27 @@ def calc_rest_sed_singlegal(
     lgfburst_pop_u_params : ndarray, shape (n_pars_lgfburst_pop, )
         Unbounded parameters controlling Fburst, which sets the fractional contribution
         of a recent burst to the smooth SFH of a galaxy. For typical values, see
-        diffsky.experimental.dspspop.lgfburstpop.DEFAULT_LGFBURST_U_PARAMS
+        dspspop.lgfburstpop.DEFAULT_LGFBURST_U_PARAMS
 
     burstshapepop_u_params : ndarray, shape (n_pars_burstshape_pop, )
         Unbounded parameters controlling the distribution of stellar ages
         of stars formed in a recent burst. For typical values, see
-        diffsky.experimental.dspspop.burstshapepop.DEFAULT_BURSTSHAPE_U_PARAMS
+        dspspop.burstshapepop.DEFAULT_BURSTSHAPE_U_PARAMS
 
     lgav_pop_u_params : ndarray, shape (n_pars_lgav_pop, )
         Unbounded parameters controlling the distribution of dust parameter Av,
         the normalization of the attenuation curve at λ_V=5500 angstrom.
         For typical values, see
-        diffsky.experimental.dspspop.lgavpop.DEFAULT_LGAV_U_PARAMS
+        dspspop.lgavpop.DEFAULT_LGAV_U_PARAMS
 
     dust_delta_pop_u_params : ndarray, shape (n_pars_dust_delta_pop, )
         Unbounded parameters controlling the distribution of dust parameter δ,
         which modifies the power-law slope of the attenuation curve. For typical values,
-        see diffsky.experimental.dspspop.dust_deltapop.DEFAULT_DUST_DELTA_U_PARAMS
+        see dspspop.dust_deltapop.DEFAULT_DUST_DELTA_U_PARAMS
 
     fracuno_pop_u_params : ndarray, shape (n_pars_fracuno_pop, )
         Unbounded parameters controlling the fraction of sightlines unobscured by dust.
-        For typical values, see diffsky.experimental.dspspop.boris_dust.DEFAULT_U_PARAMS
+        For typical values, see dspspop.boris_dust.DEFAULT_U_PARAMS
 
     cosmo_params : optional, ndarray, shape (5, )
         cosmo_params = (Om0, w0, wa, h, fb)
@@ -263,27 +259,27 @@ def calc_rest_sed_galpop(
     lgfburst_pop_u_params : ndarray, shape (n_pars_lgfburst_pop, )
         Unbounded parameters controlling Fburst, which sets the fractional contribution
         of a recent burst to the smooth SFH of a galaxy. For typical values, see
-        diffsky.experimental.dspspop.lgfburstpop.DEFAULT_LGFBURST_U_PARAMS
+        dspspop.lgfburstpop.DEFAULT_LGFBURST_U_PARAMS
 
     burstshapepop_u_params : ndarray, shape (n_pars_burstshape_pop, )
         Unbounded parameters controlling the distribution of stellar ages
         of stars formed in a recent burst. For typical values, see
-        diffsky.experimental.dspspop.burstshapepop.DEFAULT_BURSTSHAPE_U_PARAMS
+        dspspop.burstshapepop.DEFAULT_BURSTSHAPE_U_PARAMS
 
     lgav_pop_u_params : ndarray, shape (n_pars_lgav_pop, )
         Unbounded parameters controlling the distribution of dust parameter Av,
         the normalization of the attenuation curve at λ_V=5500 angstrom.
         For typical values, see
-        diffsky.experimental.dspspop.lgavpop.DEFAULT_LGAV_U_PARAMS
+        dspspop.lgavpop.DEFAULT_LGAV_U_PARAMS
 
     dust_delta_pop_u_params : ndarray, shape (n_pars_dust_delta_pop, )
         Unbounded parameters controlling the distribution of dust parameter δ,
         which modifies the power-law slope of the attenuation curve. For typical values,
-        see diffsky.experimental.dspspop.dust_deltapop.DEFAULT_DUST_DELTA_U_PARAMS
+        see dspspop.dust_deltapop.DEFAULT_DUST_DELTA_U_PARAMS
 
     fracuno_pop_u_params : ndarray, shape (n_pars_fracuno_pop, )
         Unbounded parameters controlling the fraction of sightlines unobscured by dust.
-        For typical values, see diffsky.experimental.dspspop.boris_dust.DEFAULT_U_PARAMS
+        For typical values, see dspspop.boris_dust.DEFAULT_U_PARAMS
 
     cosmo_params : optional, ndarray, shape (5, )
         cosmo_params = (Om0, w0, wa, h, fb)

--- a/lsstdesc_diffsky/sed/sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/sed_kernels_singlemet.py
@@ -1,0 +1,358 @@
+"""
+"""
+from diffsky.experimental.dspspop.boris_dust import _get_funo_from_u_params_singlegal
+from diffsky.experimental.dspspop.burstshapepop import (
+    _get_burstshape_galpop_from_params,
+)
+from diffsky.experimental.dspspop.dust_deltapop import (
+    _get_dust_delta_galpop_from_u_params,
+)
+from diffsky.experimental.dspspop.lgavpop import _get_lgav_galpop_from_u_params
+from diffsky.experimental.dspspop.lgfburstpop import _get_lgfburst_galpop_from_u_params
+from diffstar import sfh_singlegal
+from dsps.constants import N_T_LGSM_INTEGRATION, T_BIRTH_MIN
+from dsps.cosmology.flat_wcdm import _age_at_z_kern, age_at_z0
+from dsps.dust.att_curves import (
+    UV_BUMP_DW,
+    UV_BUMP_W0,
+    _frac_transmission_from_k_lambda,
+    _get_eb_from_delta,
+    sbl18_k_lambda,
+)
+from dsps.experimental.diffburst import (
+    _age_weights_from_u_params as _burst_age_weights_from_u_params,
+)
+from dsps.metallicity.mzr import mzr_model
+from dsps.sed.metallicity_weights import calc_lgmet_weights_from_lognormal_mdf
+from dsps.sed.stellar_age_weights import _calc_age_weights_from_logsm_table
+from dsps.utils import _jax_get_dt_array
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import vmap
+
+from ..defaults import DEFAULT_COSMO_PARAMS
+
+_T = (None, None, 0)
+_frac_transmission_from_k_lambda_age_vmap = jjit(
+    vmap(_frac_transmission_from_k_lambda, in_axes=_T)
+)
+
+
+@jjit
+def calc_rest_sed_singlegal(
+    z_obs,
+    diffmah_params,
+    diffstar_ms_params,
+    diffstar_q_params,
+    ssp_lgmet,
+    ssp_lg_age_gyr,
+    ssp_wave_ang,
+    ssp_flux,
+    lgfburst_pop_u_params,
+    burstshapepop_u_params,
+    lgav_pop_u_params,
+    dust_delta_pop_u_params,
+    fracuno_pop_u_params,
+    met_params,
+    cosmo_params=DEFAULT_COSMO_PARAMS,
+):
+    """Calculate the restframe SED of an individual diffsky galaxy
+
+    Parameters
+    ----------
+    z_obs : float
+        Redshift of the galaxy
+
+    diffmah_params : ndarray, shape (4, )
+        Diffmah params specifying the mass assembly of the dark matter halo
+        diffmah_params = (logm0, logtc, early_index, late_index)
+
+    diffstar_ms_params : ndarray, shape (5, )
+        Diffstar params for the star-formation effiency and gas consumption timescale
+        ms_params = (lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep)
+
+    diffstar_q_params : ndarray, shape (4, )
+        Diffstar quenching params, (lg_qt, qlglgdt, lg_drop, lg_rejuv)
+
+    ssp_lgmet : ndarray, shape (n_met, )
+        Grid in metallicity Z at which the SSPs are computed, stored as log10(Z)
+
+    ssp_lg_age_gyr : ndarray, shape (n_age, )
+        Grid in age τ at which the SSPs are computed, stored as log10(τ/Gyr)
+
+    ssp_wave_ang : ndarray, shape (n_wave, )
+        Array of wavelengths in angstroms at which the SSP SEDs are tabulated
+
+    ssp_flux : ndarray, shape (n_met, n_age, n_wave)
+        Tabulation of the SSP SEDs at the input wavelength in Lsun/Hz/Msun
+
+    lgfburst_pop_u_params : ndarray, shape (n_pars_lgfburst_pop, )
+        Unbounded parameters controlling Fburst, which sets the fractional contribution
+        of a recent burst to the smooth SFH of a galaxy. For typical values, see
+        diffsky.experimental.dspspop.lgfburstpop.DEFAULT_LGFBURST_U_PARAMS
+
+    burstshapepop_u_params : ndarray, shape (n_pars_burstshape_pop, )
+        Unbounded parameters controlling the distribution of stellar ages
+        of stars formed in a recent burst. For typical values, see
+        diffsky.experimental.dspspop.burstshapepop.DEFAULT_BURSTSHAPE_U_PARAMS
+
+    lgav_pop_u_params : ndarray, shape (n_pars_lgav_pop, )
+        Unbounded parameters controlling the distribution of dust parameter Av,
+        the normalization of the attenuation curve at λ_V=5500 angstrom.
+        For typical values, see
+        diffsky.experimental.dspspop.lgavpop.DEFAULT_LGAV_U_PARAMS
+
+    dust_delta_pop_u_params : ndarray, shape (n_pars_dust_delta_pop, )
+        Unbounded parameters controlling the distribution of dust parameter δ,
+        which modifies the power-law slope of the attenuation curve. For typical values,
+        see diffsky.experimental.dspspop.dust_deltapop.DEFAULT_DUST_DELTA_U_PARAMS
+
+    fracuno_pop_u_params : ndarray, shape (n_pars_fracuno_pop, )
+        Unbounded parameters controlling the fraction of sightlines unobscured by dust.
+        For typical values, see diffsky.experimental.dspspop.boris_dust.DEFAULT_U_PARAMS
+
+    met_params : ndarray, shape (n_pars_met_pop, ), optional
+        Parameters controlling the mass-metallicity scaling relation.
+        For typical values, see dsps.metallicity.mzr.DEFAULT_MZR_PDICT
+        mzr_params = met_params[:-1]
+        lgmet_scatter = met_params[-1]
+
+    cosmo_params : optional, ndarray, shape (5, )
+        cosmo_params = (Om0, w0, wa, h, fb)
+        Defaults set in lsstdesc_diffsky.defaults.DEFAULT_COSMO_PARAMS
+
+    Returns
+    -------
+    rest_sed : ndarray, shape (n_wave, )
+        Restframe SED of the galaxy in units of Lsun/Hz
+
+    rest_sed_nodust : ndarray, shape (n_wave, )
+        Restframe SED of the galaxy in units of Lsun/Hz, neglecting dust attenuation
+
+    logsm_t_obs : float
+        Total stellar mass formed at z_obs in units of Msun
+
+    lgmet_t_obs : float
+        Stellar metallicity at z_obs (dimensionless)
+
+    """
+    Om0, w0, wa, h, fb = cosmo_params
+    t0 = age_at_z0(Om0, w0, wa, h)
+    t_table = jnp.linspace(2 * T_BIRTH_MIN, t0, N_T_LGSM_INTEGRATION)
+    lgt0 = jnp.log10(t0)
+    t_obs = _age_at_z_kern(z_obs, Om0, w0, wa, h)
+    sfh_table = sfh_singlegal(
+        t_table,
+        diffmah_params,
+        diffstar_ms_params,
+        diffstar_q_params,
+        lgt0=lgt0,
+        fb=fb,
+    )
+
+    mzr_params, lgmet_scatter = met_params[:-1], met_params[-1]
+    _galprops_at_t_obs = _get_galprops_at_t_obs_singlegal(
+        t_obs, t_table, sfh_table, mzr_params, ssp_lg_age_gyr
+    )
+    logsm_t_obs, logssfr_t_obs, lgmet_t_obs, smooth_age_weights = _galprops_at_t_obs[:4]
+    mstar_t_obs = 10**logsm_t_obs
+
+    lgmet_weights = calc_lgmet_weights_from_lognormal_mdf(
+        lgmet_t_obs, lgmet_scatter, ssp_lgmet
+    )
+
+    # Compute burst fraction for every galaxy
+    lgfburst = _get_lgfburst_galpop_from_u_params(
+        logsm_t_obs, logssfr_t_obs, lgfburst_pop_u_params
+    )
+    fburst = 10**lgfburst
+
+    # Compute P(τ) for each bursting population
+    gal_u_lgyr_peak, gal_u_lgyr_max = _get_burstshape_galpop_from_params(
+        logsm_t_obs, logssfr_t_obs, burstshapepop_u_params
+    )
+    burstshape_u_params = jnp.array((gal_u_lgyr_peak, gal_u_lgyr_max)).T
+    ssp_lg_age_yr = ssp_lg_age_gyr + 9
+    burst_age_weights = _burst_age_weights_from_u_params(
+        ssp_lg_age_yr, burstshape_u_params
+    )
+
+    # Compute P(τ) for each composite galaxy
+    age_weights = fburst * burst_age_weights + (1 - fburst) * smooth_age_weights
+
+    n_met, n_age, n_wave = ssp_flux.shape
+    weights = lgmet_weights.reshape((n_met, 1, 1)) * age_weights.reshape((1, n_age, 1))
+    rest_sed_nodust = jnp.sum(weights * ssp_flux, axis=(0, 1)) * mstar_t_obs
+
+    lgav = _get_lgav_galpop_from_u_params(logsm_t_obs, logssfr_t_obs, lgav_pop_u_params)
+    dust_delta = _get_dust_delta_galpop_from_u_params(
+        logsm_t_obs, logssfr_t_obs, dust_delta_pop_u_params
+    )
+    frac_unobscured = _get_funo_from_u_params_singlegal(
+        logsm_t_obs, lgfburst, logssfr_t_obs, ssp_lg_age_gyr, fracuno_pop_u_params
+    )
+
+    ssp_wave_micron = ssp_wave_ang / 1e4
+    dust_Av = 10**lgav
+    dust_Eb = _get_eb_from_delta(dust_delta)
+    k_lambda = sbl18_k_lambda(
+        ssp_wave_micron, UV_BUMP_W0, UV_BUMP_DW, dust_Eb, dust_delta
+    )
+    frac_dust_trans = _frac_transmission_from_k_lambda_age_vmap(
+        k_lambda, dust_Av, frac_unobscured
+    )
+    frac_dust_trans = frac_dust_trans.reshape((1, n_age, n_wave))
+    rest_sed = jnp.sum(weights * ssp_flux * frac_dust_trans, axis=(0, 1)) * mstar_t_obs
+
+    return (rest_sed, rest_sed_nodust, logsm_t_obs, lgmet_t_obs)
+
+
+@jjit
+def _get_galprops_at_t_obs_singlegal(
+    t_obs, t_table, sfr_table, mzr_params, ssp_lg_age_gyr
+):
+    lgt_obs = jnp.log10(t_obs)
+    lgt_table = jnp.log10(t_table)
+
+    dt_table = _jax_get_dt_array(t_table)
+    logsmh_table = jnp.log10(jnp.cumsum(sfr_table * dt_table)) + 9.0
+
+    logsfr_table = jnp.log10(sfr_table)
+
+    logsm_t_obs = jnp.interp(lgt_obs, lgt_table, logsmh_table)
+    logsfr_t_obs = jnp.interp(lgt_obs, lgt_table, logsfr_table)
+    logssfr_t_obs = logsfr_t_obs - logsm_t_obs
+
+    lgmet_t_obs = mzr_model(logsm_t_obs, t_obs, *mzr_params)
+
+    __, sfr_table_age_weights = _calc_age_weights_from_logsm_table(
+        lgt_table, logsmh_table, ssp_lg_age_gyr, t_obs
+    )
+
+    return (
+        logsm_t_obs,
+        logssfr_t_obs,
+        lgmet_t_obs,
+        sfr_table_age_weights,
+    )
+
+
+_G = (0, *[0] * 3, *[None] * 11)
+_calc_rest_sed_vmap = jjit(vmap(calc_rest_sed_singlegal, in_axes=_G))
+
+
+@jjit
+def calc_rest_sed_galpop(
+    z_obs,
+    diffmah_params,
+    diffstar_ms_params,
+    diffstar_q_params,
+    ssp_lgmet,
+    ssp_lg_age_gyr,
+    ssp_wave_ang,
+    ssp_flux,
+    lgfburst_pop_u_params,
+    burstshapepop_u_params,
+    lgav_pop_u_params,
+    dust_delta_pop_u_params,
+    fracuno_pop_u_params,
+    met_params,
+    cosmo_params=DEFAULT_COSMO_PARAMS,
+):
+    """Calculate the restframe SED of a population of diffsky galaxies
+
+    Parameters
+    ----------
+    z_obs : ndarray, shape (n_gals, )
+        Redshift of the galaxies
+
+    diffmah_params : ndarray, shape (n_gals, 4)
+        Diffmah params specifying the mass assembly of the dark matter halo
+        diffmah_params = (logm0, logtc, early_index, late_index)
+
+    diffstar_ms_params : ndarray, shape (n_gals, 5)
+        Diffstar params for the star-formation effiency and gas consumption timescale
+        ms_params = (lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep)
+
+    diffstar_q_params : ndarray, shape (n_gals, 4)
+        Diffstar quenching params, (lg_qt, qlglgdt, lg_drop, lg_rejuv)
+
+    ssp_lgmet : ndarray, shape (n_met, )
+        Grid in metallicity Z at which the SSPs are computed, stored as log10(Z)
+
+    ssp_lg_age_gyr : ndarray, shape (n_age, )
+        Grid in age τ at which the SSPs are computed, stored as log10(τ/Gyr)
+
+    ssp_wave_ang : ndarray, shape (n_wave, )
+        Array of wavelengths in angstroms at which the SSP SEDs are tabulated
+
+    ssp_flux : ndarray, shape (n_met, n_age, n_wave)
+        Tabulation of the SSP SEDs at the input wavelength in Lsun/Hz/Msun
+
+    lgfburst_pop_u_params : ndarray, shape (n_pars_lgfburst_pop, )
+        Unbounded parameters controlling Fburst, which sets the fractional contribution
+        of a recent burst to the smooth SFH of a galaxy. For typical values, see
+        diffsky.experimental.dspspop.lgfburstpop.DEFAULT_LGFBURST_U_PARAMS
+
+    burstshapepop_u_params : ndarray, shape (n_pars_burstshape_pop, )
+        Unbounded parameters controlling the distribution of stellar ages
+        of stars formed in a recent burst. For typical values, see
+        diffsky.experimental.dspspop.burstshapepop.DEFAULT_BURSTSHAPE_U_PARAMS
+
+    lgav_pop_u_params : ndarray, shape (n_pars_lgav_pop, )
+        Unbounded parameters controlling the distribution of dust parameter Av,
+        the normalization of the attenuation curve at λ_V=5500 angstrom.
+        For typical values, see
+        diffsky.experimental.dspspop.lgavpop.DEFAULT_LGAV_U_PARAMS
+
+    dust_delta_pop_u_params : ndarray, shape (n_pars_dust_delta_pop, )
+        Unbounded parameters controlling the distribution of dust parameter δ,
+        which modifies the power-law slope of the attenuation curve. For typical values,
+        see diffsky.experimental.dspspop.dust_deltapop.DEFAULT_DUST_DELTA_U_PARAMS
+
+    fracuno_pop_u_params : ndarray, shape (n_pars_fracuno_pop, )
+        Unbounded parameters controlling the fraction of sightlines unobscured by dust.
+        For typical values, see diffsky.experimental.dspspop.boris_dust.DEFAULT_U_PARAMS
+
+    met_params : ndarray, shape (n_pars_met_pop, ), optional
+        Parameters controlling the mass-metallicity scaling relation.
+        For typical values, see dsps.metallicity.mzr.DEFAULT_MZR_PDICT
+        mzr_params = met_params[:-1]
+        lgmet_scatter = met_params[-1]
+
+    cosmo_params : optional, ndarray, shape (5, )
+        cosmo_params = (Om0, w0, wa, h, fb)
+        Defaults set in lsstdesc_diffsky.defaults.DEFAULT_COSMO_PARAMS
+
+    Returns
+    -------
+    rest_sed : ndarray, shape (n_gals, n_wave)
+        Restframe SED of the galaxy in units of Lsun/Hz
+
+    rest_sed_nodust : ndarray, shape (n_gals, n_wave)
+        Restframe SED of the galaxy in units of Lsun/Hz, neglecting dust attenuation
+
+    logsm_t_obs : ndarray, shape (n_gals, )
+        Total stellar mass formed at z_obs in units of Msun
+
+    lgmet_t_obs : ndarray, shape (n_gals, )
+        Stellar metallicity at z_obs (dimensionless)
+
+    """
+    return _calc_rest_sed_vmap(
+        z_obs,
+        diffmah_params,
+        diffstar_ms_params,
+        diffstar_q_params,
+        ssp_lgmet,
+        ssp_lg_age_gyr,
+        ssp_wave_ang,
+        ssp_flux,
+        lgfburst_pop_u_params,
+        burstshapepop_u_params,
+        lgav_pop_u_params,
+        dust_delta_pop_u_params,
+        fracuno_pop_u_params,
+        met_params,
+        cosmo_params,
+    )

--- a/lsstdesc_diffsky/sed/sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/sed_kernels_singlemet.py
@@ -43,11 +43,7 @@ def calc_rest_sed_singlegal(
     diffstar_ms_params,
     diffstar_q_params,
     ssp_data,
-    lgfburst_pop_u_params,
-    burstshapepop_u_params,
-    lgav_pop_u_params,
-    dust_delta_pop_u_params,
-    fracuno_pop_u_params,
+    diffskypop_data,
     cosmo_params=DEFAULT_COSMO_PARAMS,
 ):
     """Calculate the restframe SED of an individual diffsky galaxy
@@ -143,13 +139,13 @@ def calc_rest_sed_singlegal(
 
     # Compute burst fraction for every galaxy
     lgfburst = _get_lgfburst_galpop_from_u_params(
-        logsm_t_obs, logssfr_t_obs, lgfburst_pop_u_params
+        logsm_t_obs, logssfr_t_obs, diffskypop_data.lgfburst_u_params
     )
     fburst = 10**lgfburst
 
     # Compute P(τ) for each bursting population
     gal_u_lgyr_peak, gal_u_lgyr_max = _get_burstshape_galpop_from_params(
-        logsm_t_obs, logssfr_t_obs, burstshapepop_u_params
+        logsm_t_obs, logssfr_t_obs, diffskypop_data.burstshape_u_params
     )
     burstshape_u_params = jnp.array((gal_u_lgyr_peak, gal_u_lgyr_max)).T
     ssp_lg_age_yr = ssp_data.ssp_lg_age_gyr + 9
@@ -164,16 +160,18 @@ def calc_rest_sed_singlegal(
     weights = age_weights.reshape((n_age, 1))
     rest_sed_nodust = jnp.sum(weights * ssp_data.ssp_flux, axis=(0,)) * mstar_t_obs
 
-    lgav = _get_lgav_galpop_from_u_params(logsm_t_obs, logssfr_t_obs, lgav_pop_u_params)
+    lgav = _get_lgav_galpop_from_u_params(
+        logsm_t_obs, logssfr_t_obs, diffskypop_data.lgav_dust_u_params
+    )
     dust_delta = _get_dust_delta_galpop_from_u_params(
-        logsm_t_obs, logssfr_t_obs, dust_delta_pop_u_params
+        logsm_t_obs, logssfr_t_obs, diffskypop_data.delta_dust_u_params
     )
     frac_unobscured = _get_funo_from_u_params_singlegal(
         logsm_t_obs,
         lgfburst,
         logssfr_t_obs,
         ssp_data.ssp_lg_age_gyr,
-        fracuno_pop_u_params,
+        diffskypop_data.funo_dust_u_params,
     )
 
     ssp_wave_micron = ssp_data.ssp_wave / 1e4
@@ -218,7 +216,7 @@ def _get_galprops_at_t_obs_singlegal(t_obs, t_table, sfr_table, ssp_lg_age_gyr):
     )
 
 
-_G = (0, *[0] * 3, *[None] * 7)
+_G = (0, *[0] * 3, *[None] * 3)
 _calc_rest_sed_vmap = jjit(vmap(calc_rest_sed_singlegal, in_axes=_G))
 
 
@@ -229,11 +227,7 @@ def calc_rest_sed_galpop(
     diffstar_ms_params,
     diffstar_q_params,
     ssp_data,
-    lgfburst_pop_u_params,
-    burstshapepop_u_params,
-    lgav_pop_u_params,
-    dust_delta_pop_u_params,
-    fracuno_pop_u_params,
+    diffskypop_data,
     cosmo_params=DEFAULT_COSMO_PARAMS,
 ):
     """Calculate the restframe SED of a population of diffsky galaxies
@@ -313,10 +307,6 @@ def calc_rest_sed_galpop(
         diffstar_ms_params,
         diffstar_q_params,
         ssp_data,
-        lgfburst_pop_u_params,
-        burstshapepop_u_params,
-        lgav_pop_u_params,
-        dust_delta_pop_u_params,
-        fracuno_pop_u_params,
+        diffskypop_data,
         cosmo_params,
     )

--- a/lsstdesc_diffsky/sed/sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/sed_kernels_singlemet.py
@@ -43,7 +43,7 @@ def calc_rest_sed_singlegal(
     diffstar_ms_params,
     diffstar_q_params,
     ssp_data,
-    diffskypop_data,
+    diffskypop_params,
     cosmo_params=DEFAULT_COSMO_PARAMS,
 ):
     """Calculate the restframe SED of an individual diffsky galaxy
@@ -139,13 +139,13 @@ def calc_rest_sed_singlegal(
 
     # Compute burst fraction for every galaxy
     lgfburst = _get_lgfburst_galpop_from_u_params(
-        logsm_t_obs, logssfr_t_obs, diffskypop_data.lgfburst_u_params
+        logsm_t_obs, logssfr_t_obs, diffskypop_params.lgfburst_u_params
     )
     fburst = 10**lgfburst
 
     # Compute P(τ) for each bursting population
     gal_u_lgyr_peak, gal_u_lgyr_max = _get_burstshape_galpop_from_params(
-        logsm_t_obs, logssfr_t_obs, diffskypop_data.burstshape_u_params
+        logsm_t_obs, logssfr_t_obs, diffskypop_params.burstshape_u_params
     )
     burstshape_u_params = jnp.array((gal_u_lgyr_peak, gal_u_lgyr_max)).T
     ssp_lg_age_yr = ssp_data.ssp_lg_age_gyr + 9
@@ -161,17 +161,17 @@ def calc_rest_sed_singlegal(
     rest_sed_nodust = jnp.sum(weights * ssp_data.ssp_flux, axis=(0,)) * mstar_t_obs
 
     lgav = _get_lgav_galpop_from_u_params(
-        logsm_t_obs, logssfr_t_obs, diffskypop_data.lgav_dust_u_params
+        logsm_t_obs, logssfr_t_obs, diffskypop_params.lgav_dust_u_params
     )
     dust_delta = _get_dust_delta_galpop_from_u_params(
-        logsm_t_obs, logssfr_t_obs, diffskypop_data.delta_dust_u_params
+        logsm_t_obs, logssfr_t_obs, diffskypop_params.delta_dust_u_params
     )
     frac_unobscured = _get_funo_from_u_params_singlegal(
         logsm_t_obs,
         lgfburst,
         logssfr_t_obs,
         ssp_data.ssp_lg_age_gyr,
-        diffskypop_data.funo_dust_u_params,
+        diffskypop_params.funo_dust_u_params,
     )
 
     ssp_wave_micron = ssp_data.ssp_wave / 1e4
@@ -227,7 +227,7 @@ def calc_rest_sed_galpop(
     diffstar_ms_params,
     diffstar_q_params,
     ssp_data,
-    diffskypop_data,
+    diffskypop_params,
     cosmo_params=DEFAULT_COSMO_PARAMS,
 ):
     """Calculate the restframe SED of a population of diffsky galaxies
@@ -307,6 +307,6 @@ def calc_rest_sed_galpop(
         diffstar_ms_params,
         diffstar_q_params,
         ssp_data,
-        diffskypop_data,
+        diffskypop_params,
         cosmo_params,
     )

--- a/lsstdesc_diffsky/sed/sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/sed_kernels_singlemet.py
@@ -23,7 +23,6 @@ from dsps.experimental.diffburst import (
     _age_weights_from_u_params as _burst_age_weights_from_u_params,
 )
 from dsps.metallicity.mzr import mzr_model
-from dsps.sed.metallicity_weights import calc_lgmet_weights_from_lognormal_mdf
 from dsps.sed.stellar_age_weights import _calc_age_weights_from_logsm_table
 from dsps.utils import _jax_get_dt_array
 from jax import jit as jjit
@@ -157,10 +156,6 @@ def calc_rest_sed_singlegal(
     logsm_t_obs, logssfr_t_obs, lgmet_t_obs, smooth_age_weights = _galprops_at_t_obs[:4]
     mstar_t_obs = 10**logsm_t_obs
 
-    lgmet_weights = calc_lgmet_weights_from_lognormal_mdf(
-        lgmet_t_obs, lgmet_scatter, ssp_lgmet
-    )
-
     # Compute burst fraction for every galaxy
     lgfburst = _get_lgfburst_galpop_from_u_params(
         logsm_t_obs, logssfr_t_obs, lgfburst_pop_u_params
@@ -181,7 +176,7 @@ def calc_rest_sed_singlegal(
     age_weights = fburst * burst_age_weights + (1 - fburst) * smooth_age_weights
 
     n_met, n_age, n_wave = ssp_flux.shape
-    weights = lgmet_weights.reshape((n_met, 1, 1)) * age_weights.reshape((1, n_age, 1))
+    weights = age_weights.reshape((1, n_age, 1))
     rest_sed_nodust = jnp.sum(weights * ssp_flux, axis=(0, 1)) * mstar_t_obs
 
     lgav = _get_lgav_galpop_from_u_params(logsm_t_obs, logssfr_t_obs, lgav_pop_u_params)

--- a/lsstdesc_diffsky/sed/tests/test_disk_bulge_sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/tests/test_disk_bulge_sed_kernels_singlemet.py
@@ -1,0 +1,80 @@
+"""
+"""
+import numpy as np
+from dsps.data_loaders.retrieve_fake_fsps_data import load_fake_ssp_data
+
+from ... import read_diffskypop_params
+from ...defaults import DEFAULT_DIFFGAL_PARAMS, DEFAULT_FBULGE_PARAMS
+from ..disk_bulge_sed_kernels_singlemet import (
+    calc_rest_sed_disk_bulge_knot_galpop,
+    calc_rest_sed_disk_bulge_knot_singlegal,
+)
+
+
+def test_calc_rest_sed_evaluates_with_roman_rubin_2023_params():
+    all_params = read_diffskypop_params("roman_rubin_2023")
+
+    z_obs = 0.1
+
+    ssp_data = load_fake_ssp_data()
+    mah_params, ms_params, q_params = DEFAULT_DIFFGAL_PARAMS
+
+    fknot = 0.05
+    _res = calc_rest_sed_disk_bulge_knot_singlegal(
+        z_obs,
+        mah_params,
+        ms_params,
+        q_params,
+        DEFAULT_FBULGE_PARAMS,
+        fknot,
+        ssp_data.ssp_lgmet,
+        ssp_data.ssp_lg_age_gyr,
+        ssp_data.ssp_wave,
+        ssp_data.ssp_flux,
+        *all_params,
+    )
+    for x in _res:
+        assert np.all(np.isfinite(x))
+
+
+def test_calc_rest_sed_disk_bulge_knot_galpop():
+    n_gals = 5
+
+    z_obs_galpop = np.random.uniform(0.02, 1, n_gals)
+
+    mah_params, ms_params, q_params = DEFAULT_DIFFGAL_PARAMS
+
+    mah_params_galpop = np.tile(mah_params, n_gals)
+    mah_params_galpop = mah_params_galpop.reshape((n_gals, -1))
+
+    ms_params_galpop = np.tile(ms_params, n_gals)
+    ms_params_galpop = ms_params_galpop.reshape((n_gals, -1))
+
+    q_params_galpop = np.tile(q_params, n_gals)
+    q_params_galpop = q_params_galpop.reshape((n_gals, -1))
+
+    fbulge_params_galpop = np.tile(DEFAULT_FBULGE_PARAMS, n_gals)
+    fbulge_params_galpop = fbulge_params_galpop.reshape((n_gals, -1))
+
+    fknot_galpop = np.random.uniform(0, 0.1, n_gals)
+
+    ssp_data = load_fake_ssp_data()
+    n_met, n_age, n_wave = ssp_data.ssp_flux.shape
+
+    all_mock_params = read_diffskypop_params("roman_rubin_2023")
+
+    _res = calc_rest_sed_disk_bulge_knot_galpop(
+        z_obs_galpop,
+        mah_params_galpop,
+        ms_params_galpop,
+        q_params_galpop,
+        fbulge_params_galpop,
+        fknot_galpop,
+        ssp_data.ssp_lgmet,
+        ssp_data.ssp_lg_age_gyr,
+        ssp_data.ssp_wave,
+        ssp_data.ssp_flux,
+        *all_mock_params,
+    )
+    for x in _res:
+        assert np.all(np.isfinite(x))

--- a/lsstdesc_diffsky/sed/tests/test_disk_bulge_sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/tests/test_disk_bulge_sed_kernels_singlemet.py
@@ -14,7 +14,7 @@ from ..disk_bulge_sed_kernels_singlemet import (
 
 
 def test_calc_rest_sed_evaluates_with_roman_rubin_2023_params():
-    all_params = read_diffskypop_params("roman_rubin_2023")[:-1]
+    diffskypop_params = read_diffskypop_params("roman_rubin_2023")
 
     z_obs = 0.1
 
@@ -30,7 +30,7 @@ def test_calc_rest_sed_evaluates_with_roman_rubin_2023_params():
         DEFAULT_FBULGE_PARAMS,
         fknot,
         ssp_data,
-        *all_params,
+        diffskypop_params,
     )
     for x in _res:
         assert np.all(np.isfinite(x))
@@ -60,7 +60,7 @@ def test_calc_rest_sed_disk_bulge_knot_galpop():
     ssp_data = load_fake_ssp_data_singlemet()
     n_age, n_wave = ssp_data.ssp_flux.shape
 
-    all_mock_params = read_diffskypop_params("roman_rubin_2023")[:-1]
+    diffskypop_params = read_diffskypop_params("roman_rubin_2023")
 
     _res = calc_rest_sed_disk_bulge_knot_galpop(
         z_obs_galpop,
@@ -70,7 +70,7 @@ def test_calc_rest_sed_disk_bulge_knot_galpop():
         fbulge_params_galpop,
         fknot_galpop,
         ssp_data,
-        *all_mock_params,
+        diffskypop_params,
     )
     for x in _res:
         assert np.all(np.isfinite(x))

--- a/lsstdesc_diffsky/sed/tests/test_disk_bulge_sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/tests/test_disk_bulge_sed_kernels_singlemet.py
@@ -1,10 +1,12 @@
 """
 """
 import numpy as np
-from dsps.data_loaders.retrieve_fake_fsps_data import load_fake_ssp_data
 
 from ... import read_diffskypop_params
 from ...defaults import DEFAULT_DIFFGAL_PARAMS, DEFAULT_FBULGE_PARAMS
+from ...legacy.roman_rubin_2023.dsps.data_loaders.retrieve_fake_fsps_data import (
+    load_fake_ssp_data_singlemet,
+)
 from ..disk_bulge_sed_kernels_singlemet import (
     calc_rest_sed_disk_bulge_knot_galpop,
     calc_rest_sed_disk_bulge_knot_singlegal,
@@ -12,11 +14,11 @@ from ..disk_bulge_sed_kernels_singlemet import (
 
 
 def test_calc_rest_sed_evaluates_with_roman_rubin_2023_params():
-    all_params = read_diffskypop_params("roman_rubin_2023")
+    all_params = read_diffskypop_params("roman_rubin_2023")[:-1]
 
     z_obs = 0.1
 
-    ssp_data = load_fake_ssp_data()
+    ssp_data = load_fake_ssp_data_singlemet()
     mah_params, ms_params, q_params = DEFAULT_DIFFGAL_PARAMS
 
     fknot = 0.05
@@ -27,10 +29,7 @@ def test_calc_rest_sed_evaluates_with_roman_rubin_2023_params():
         q_params,
         DEFAULT_FBULGE_PARAMS,
         fknot,
-        ssp_data.ssp_lgmet,
-        ssp_data.ssp_lg_age_gyr,
-        ssp_data.ssp_wave,
-        ssp_data.ssp_flux,
+        ssp_data,
         *all_params,
     )
     for x in _res:
@@ -58,10 +57,10 @@ def test_calc_rest_sed_disk_bulge_knot_galpop():
 
     fknot_galpop = np.random.uniform(0, 0.1, n_gals)
 
-    ssp_data = load_fake_ssp_data()
-    n_met, n_age, n_wave = ssp_data.ssp_flux.shape
+    ssp_data = load_fake_ssp_data_singlemet()
+    n_age, n_wave = ssp_data.ssp_flux.shape
 
-    all_mock_params = read_diffskypop_params("roman_rubin_2023")
+    all_mock_params = read_diffskypop_params("roman_rubin_2023")[:-1]
 
     _res = calc_rest_sed_disk_bulge_knot_galpop(
         z_obs_galpop,
@@ -70,10 +69,7 @@ def test_calc_rest_sed_disk_bulge_knot_galpop():
         q_params_galpop,
         fbulge_params_galpop,
         fknot_galpop,
-        ssp_data.ssp_lgmet,
-        ssp_data.ssp_lg_age_gyr,
-        ssp_data.ssp_wave,
-        ssp_data.ssp_flux,
+        ssp_data,
         *all_mock_params,
     )
     for x in _res:

--- a/lsstdesc_diffsky/sed/tests/test_sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/tests/test_sed_kernels_singlemet.py
@@ -1,0 +1,133 @@
+"""
+"""
+import numpy as np
+from diffmah.defaults import DEFAULT_MAH_PARAMS
+from diffsky.experimental.dspspop.boris_dust import (
+    DEFAULT_U_PARAMS as DEFAULT_FUNO_U_PARAMS,
+)
+from diffsky.experimental.dspspop.burstshapepop import DEFAULT_BURSTSHAPE_U_PARAMS
+from diffsky.experimental.dspspop.dust_deltapop import DEFAULT_DUST_DELTA_U_PARAMS
+from diffsky.experimental.dspspop.lgavpop import DEFAULT_LGAV_U_PARAMS
+from diffsky.experimental.dspspop.lgfburstpop import DEFAULT_LGFBURST_U_PARAMS
+from diffstar.defaults import DEFAULT_MS_PARAMS, DEFAULT_Q_PARAMS
+from dsps.data_loaders.retrieve_fake_fsps_data import load_fake_ssp_data
+from dsps.metallicity.defaults import DEFAULT_MET_PARAMS
+
+from ... import read_diffskypop_params
+from ..sed_kernels_singlemet import calc_rest_sed_galpop, calc_rest_sed_singlegal
+
+
+def test_calc_rest_sed_evaluates_with_default_params():
+    z_obs = 0.1
+
+    ssp_data = load_fake_ssp_data()
+    _res = calc_rest_sed_singlegal(
+        z_obs,
+        DEFAULT_MAH_PARAMS,
+        DEFAULT_MS_PARAMS,
+        DEFAULT_Q_PARAMS,
+        ssp_data.ssp_lgmet,
+        ssp_data.ssp_lg_age_gyr,
+        ssp_data.ssp_wave,
+        ssp_data.ssp_flux,
+        DEFAULT_LGFBURST_U_PARAMS,
+        DEFAULT_BURSTSHAPE_U_PARAMS,
+        DEFAULT_LGAV_U_PARAMS,
+        DEFAULT_DUST_DELTA_U_PARAMS,
+        DEFAULT_FUNO_U_PARAMS,
+        DEFAULT_MET_PARAMS,
+    )
+    (
+        rest_sed,
+        rest_sed_nodust,
+        logsm_t_obs,
+        lgmet_t_obs,
+    ) = _res
+    for x in _res:
+        assert np.all(np.isfinite(x))
+
+    n_met, n_age, n_wave = ssp_data.ssp_flux.shape
+
+    assert np.all(rest_sed <= rest_sed_nodust)
+    assert np.any(rest_sed < rest_sed_nodust)
+
+    assert rest_sed.shape == rest_sed_nodust.shape
+    assert rest_sed.shape == (n_wave,)
+
+
+def test_calc_rest_sed_evaluates_with_roman_rubin_2023_params():
+    all_params = read_diffskypop_params("roman_rubin_2023")
+
+    z_obs = 0.1
+
+    ssp_data = load_fake_ssp_data()
+    _res = calc_rest_sed_singlegal(
+        z_obs,
+        DEFAULT_MAH_PARAMS,
+        DEFAULT_MS_PARAMS,
+        DEFAULT_Q_PARAMS,
+        ssp_data.ssp_lgmet,
+        ssp_data.ssp_lg_age_gyr,
+        ssp_data.ssp_wave,
+        ssp_data.ssp_flux,
+        *all_params,
+    )
+    (
+        rest_sed,
+        rest_sed_nodust,
+        logsm_t_obs,
+        lgmet_t_obs,
+    ) = _res
+    for x in _res:
+        assert np.all(np.isfinite(x))
+
+    n_met, n_age, n_wave = ssp_data.ssp_flux.shape
+
+    assert np.all(rest_sed <= rest_sed_nodust)
+    assert np.any(rest_sed < rest_sed_nodust)
+
+    assert rest_sed.shape == rest_sed_nodust.shape
+    assert rest_sed.shape == (n_wave,)
+
+
+def test_calc_rest_sed_galpop():
+    n_gals = 5
+
+    z_obs_galpop = np.random.uniform(0, 1, n_gals)
+
+    mah_params_galpop = np.tile(DEFAULT_MAH_PARAMS, n_gals)
+    mah_params_galpop = mah_params_galpop.reshape((n_gals, -1))
+
+    ms_params_galpop = np.tile(DEFAULT_MS_PARAMS, n_gals)
+    ms_params_galpop = ms_params_galpop.reshape((n_gals, -1))
+
+    q_params_galpop = np.tile(DEFAULT_Q_PARAMS, n_gals)
+    q_params_galpop = q_params_galpop.reshape((n_gals, -1))
+
+    ssp_data = load_fake_ssp_data()
+    n_met, n_age, n_wave = ssp_data.ssp_flux.shape
+
+    all_mock_params = read_diffskypop_params("roman_rubin_2023")
+
+    _res = calc_rest_sed_galpop(
+        z_obs_galpop,
+        mah_params_galpop,
+        ms_params_galpop,
+        q_params_galpop,
+        *ssp_data,
+        *all_mock_params,
+    )
+    for x in _res:
+        assert np.all(np.isfinite(x))
+
+    rest_sed_galpop, rest_sed_nodust_galpop = _res[:2]
+    logsm_t_obs_galpop, lgmet_t_obs_galpop = _res[2:]
+    assert rest_sed_galpop.shape == (n_gals, n_wave)
+
+    assert np.all(rest_sed_galpop <= rest_sed_nodust_galpop)
+    assert np.any(rest_sed_galpop < rest_sed_nodust_galpop)
+    assert np.all(logsm_t_obs_galpop > 0)
+    assert np.all(logsm_t_obs_galpop < 15)
+
+    assert np.all(lgmet_t_obs_galpop > -4)
+    assert np.all(lgmet_t_obs_galpop < 1)

--- a/lsstdesc_diffsky/sed/tests/test_sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/tests/test_sed_kernels_singlemet.py
@@ -2,13 +2,6 @@
 """
 import numpy as np
 from diffmah.defaults import DEFAULT_MAH_PARAMS
-from diffsky.experimental.dspspop.boris_dust import (
-    DEFAULT_U_PARAMS as DEFAULT_FUNO_U_PARAMS,
-)
-from diffsky.experimental.dspspop.burstshapepop import DEFAULT_BURSTSHAPE_U_PARAMS
-from diffsky.experimental.dspspop.dust_deltapop import DEFAULT_DUST_DELTA_U_PARAMS
-from diffsky.experimental.dspspop.lgavpop import DEFAULT_LGAV_U_PARAMS
-from diffsky.experimental.dspspop.lgfburstpop import DEFAULT_LGFBURST_U_PARAMS
 from diffstar.defaults import DEFAULT_MS_PARAMS, DEFAULT_Q_PARAMS
 
 from ... import read_diffskypop_params
@@ -22,17 +15,14 @@ def test_calc_rest_sed_evaluates_with_default_params():
     z_obs = 0.1
 
     ssp_data = load_fake_ssp_data_singlemet()
+    diffskypop_data = read_diffskypop_params("roman_rubin_2023")
     _res = calc_rest_sed_singlegal(
         z_obs,
         DEFAULT_MAH_PARAMS,
         DEFAULT_MS_PARAMS,
         DEFAULT_Q_PARAMS,
         ssp_data,
-        DEFAULT_LGFBURST_U_PARAMS,
-        DEFAULT_BURSTSHAPE_U_PARAMS,
-        DEFAULT_LGAV_U_PARAMS,
-        DEFAULT_DUST_DELTA_U_PARAMS,
-        DEFAULT_FUNO_U_PARAMS,
+        diffskypop_data,
     )
     (
         rest_sed,
@@ -52,7 +42,7 @@ def test_calc_rest_sed_evaluates_with_default_params():
 
 
 def test_calc_rest_sed_evaluates_with_roman_rubin_2023_params():
-    all_params = read_diffskypop_params("roman_rubin_2023")[:-1]
+    all_params = read_diffskypop_params("roman_rubin_2023")
 
     z_obs = 0.1
 
@@ -63,7 +53,7 @@ def test_calc_rest_sed_evaluates_with_roman_rubin_2023_params():
         DEFAULT_MS_PARAMS,
         DEFAULT_Q_PARAMS,
         ssp_data,
-        *all_params,
+        all_params,
     )
     (
         rest_sed,
@@ -99,7 +89,7 @@ def test_calc_rest_sed_galpop():
     ssp_data = load_fake_ssp_data_singlemet()
     n_age, n_wave = ssp_data.ssp_flux.shape
 
-    all_mock_params = read_diffskypop_params("roman_rubin_2023")[:-1]
+    diffskypop_data = read_diffskypop_params("roman_rubin_2023")
 
     _res = calc_rest_sed_galpop(
         z_obs_galpop,
@@ -107,7 +97,7 @@ def test_calc_rest_sed_galpop():
         ms_params_galpop,
         q_params_galpop,
         ssp_data,
-        *all_mock_params,
+        diffskypop_data,
     )
     for x in _res:
         assert np.all(np.isfinite(x))

--- a/lsstdesc_diffsky/sed/tests/test_sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/tests/test_sed_kernels_singlemet.py
@@ -10,7 +10,6 @@ from diffsky.experimental.dspspop.dust_deltapop import DEFAULT_DUST_DELTA_U_PARA
 from diffsky.experimental.dspspop.lgavpop import DEFAULT_LGAV_U_PARAMS
 from diffsky.experimental.dspspop.lgfburstpop import DEFAULT_LGFBURST_U_PARAMS
 from diffstar.defaults import DEFAULT_MS_PARAMS, DEFAULT_Q_PARAMS
-from dsps.metallicity.defaults import DEFAULT_MET_PARAMS
 
 from ... import read_diffskypop_params
 from ...legacy.roman_rubin_2023.dsps.data_loaders.retrieve_fake_fsps_data import (
@@ -34,13 +33,11 @@ def test_calc_rest_sed_evaluates_with_default_params():
         DEFAULT_LGAV_U_PARAMS,
         DEFAULT_DUST_DELTA_U_PARAMS,
         DEFAULT_FUNO_U_PARAMS,
-        DEFAULT_MET_PARAMS,
     )
     (
         rest_sed,
         rest_sed_nodust,
         logsm_t_obs,
-        lgmet_t_obs,
     ) = _res
     for x in _res:
         assert np.all(np.isfinite(x))
@@ -55,7 +52,7 @@ def test_calc_rest_sed_evaluates_with_default_params():
 
 
 def test_calc_rest_sed_evaluates_with_roman_rubin_2023_params():
-    all_params = read_diffskypop_params("roman_rubin_2023")
+    all_params = read_diffskypop_params("roman_rubin_2023")[:-1]
 
     z_obs = 0.1
 
@@ -72,7 +69,6 @@ def test_calc_rest_sed_evaluates_with_roman_rubin_2023_params():
         rest_sed,
         rest_sed_nodust,
         logsm_t_obs,
-        lgmet_t_obs,
     ) = _res
     for x in _res:
         assert np.all(np.isfinite(x))
@@ -103,7 +99,7 @@ def test_calc_rest_sed_galpop():
     ssp_data = load_fake_ssp_data_singlemet()
     n_age, n_wave = ssp_data.ssp_flux.shape
 
-    all_mock_params = read_diffskypop_params("roman_rubin_2023")
+    all_mock_params = read_diffskypop_params("roman_rubin_2023")[:-1]
 
     _res = calc_rest_sed_galpop(
         z_obs_galpop,
@@ -116,14 +112,10 @@ def test_calc_rest_sed_galpop():
     for x in _res:
         assert np.all(np.isfinite(x))
 
-    rest_sed_galpop, rest_sed_nodust_galpop = _res[:2]
-    logsm_t_obs_galpop, lgmet_t_obs_galpop = _res[2:]
+    rest_sed_galpop, rest_sed_nodust_galpop, logsm_t_obs_galpop = _res[:3]
     assert rest_sed_galpop.shape == (n_gals, n_wave)
 
     assert np.all(rest_sed_galpop <= rest_sed_nodust_galpop)
     assert np.any(rest_sed_galpop < rest_sed_nodust_galpop)
     assert np.all(logsm_t_obs_galpop > 0)
     assert np.all(logsm_t_obs_galpop < 15)
-
-    assert np.all(lgmet_t_obs_galpop > -4)
-    assert np.all(lgmet_t_obs_galpop < 1)

--- a/lsstdesc_diffsky/sed/tests/test_sed_kernels_singlemet.py
+++ b/lsstdesc_diffsky/sed/tests/test_sed_kernels_singlemet.py
@@ -10,26 +10,25 @@ from diffsky.experimental.dspspop.dust_deltapop import DEFAULT_DUST_DELTA_U_PARA
 from diffsky.experimental.dspspop.lgavpop import DEFAULT_LGAV_U_PARAMS
 from diffsky.experimental.dspspop.lgfburstpop import DEFAULT_LGFBURST_U_PARAMS
 from diffstar.defaults import DEFAULT_MS_PARAMS, DEFAULT_Q_PARAMS
-from dsps.data_loaders.retrieve_fake_fsps_data import load_fake_ssp_data
 from dsps.metallicity.defaults import DEFAULT_MET_PARAMS
 
 from ... import read_diffskypop_params
+from ...legacy.roman_rubin_2023.dsps.data_loaders.retrieve_fake_fsps_data import (
+    load_fake_ssp_data_singlemet,
+)
 from ..sed_kernels_singlemet import calc_rest_sed_galpop, calc_rest_sed_singlegal
 
 
 def test_calc_rest_sed_evaluates_with_default_params():
     z_obs = 0.1
 
-    ssp_data = load_fake_ssp_data()
+    ssp_data = load_fake_ssp_data_singlemet()
     _res = calc_rest_sed_singlegal(
         z_obs,
         DEFAULT_MAH_PARAMS,
         DEFAULT_MS_PARAMS,
         DEFAULT_Q_PARAMS,
-        ssp_data.ssp_lgmet,
-        ssp_data.ssp_lg_age_gyr,
-        ssp_data.ssp_wave,
-        ssp_data.ssp_flux,
+        ssp_data,
         DEFAULT_LGFBURST_U_PARAMS,
         DEFAULT_BURSTSHAPE_U_PARAMS,
         DEFAULT_LGAV_U_PARAMS,
@@ -46,7 +45,7 @@ def test_calc_rest_sed_evaluates_with_default_params():
     for x in _res:
         assert np.all(np.isfinite(x))
 
-    n_met, n_age, n_wave = ssp_data.ssp_flux.shape
+    n_age, n_wave = ssp_data.ssp_flux.shape
 
     assert np.all(rest_sed <= rest_sed_nodust)
     assert np.any(rest_sed < rest_sed_nodust)
@@ -60,16 +59,13 @@ def test_calc_rest_sed_evaluates_with_roman_rubin_2023_params():
 
     z_obs = 0.1
 
-    ssp_data = load_fake_ssp_data()
+    ssp_data = load_fake_ssp_data_singlemet()
     _res = calc_rest_sed_singlegal(
         z_obs,
         DEFAULT_MAH_PARAMS,
         DEFAULT_MS_PARAMS,
         DEFAULT_Q_PARAMS,
-        ssp_data.ssp_lgmet,
-        ssp_data.ssp_lg_age_gyr,
-        ssp_data.ssp_wave,
-        ssp_data.ssp_flux,
+        ssp_data,
         *all_params,
     )
     (
@@ -81,7 +77,7 @@ def test_calc_rest_sed_evaluates_with_roman_rubin_2023_params():
     for x in _res:
         assert np.all(np.isfinite(x))
 
-    n_met, n_age, n_wave = ssp_data.ssp_flux.shape
+    n_age, n_wave = ssp_data.ssp_flux.shape
 
     assert np.all(rest_sed <= rest_sed_nodust)
     assert np.any(rest_sed < rest_sed_nodust)
@@ -104,8 +100,8 @@ def test_calc_rest_sed_galpop():
     q_params_galpop = np.tile(DEFAULT_Q_PARAMS, n_gals)
     q_params_galpop = q_params_galpop.reshape((n_gals, -1))
 
-    ssp_data = load_fake_ssp_data()
-    n_met, n_age, n_wave = ssp_data.ssp_flux.shape
+    ssp_data = load_fake_ssp_data_singlemet()
+    n_age, n_wave = ssp_data.ssp_flux.shape
 
     all_mock_params = read_diffskypop_params("roman_rubin_2023")
 
@@ -114,7 +110,7 @@ def test_calc_rest_sed_galpop():
         mah_params_galpop,
         ms_params_galpop,
         q_params_galpop,
-        *ssp_data,
+        ssp_data,
         *all_mock_params,
     )
     for x in _res:

--- a/lsstdesc_diffsky/tests/test_write_mock_to_disk_singlemet.py
+++ b/lsstdesc_diffsky/tests/test_write_mock_to_disk_singlemet.py
@@ -1,0 +1,20 @@
+"""
+"""
+# flake8: noqa
+import pytest
+
+
+def test_write_mock_to_disk_imports():
+    from .. import write_mock_to_disk_singlemet
+
+
+@pytest.mark.xfail
+def test_write_mock_to_disk_has_no_hard_coding_relics():
+    from .. import write_mock_to_disk_singlemet
+
+    pat = "write_mock_to_disk should not have a hard-coded variable {}"
+
+    list_of_hard_coding_errors = ("Ntotal_synthetics",)
+    for attr in list_of_hard_coding_errors:
+        msg = pat.format(attr)
+        assert not hasattr(write_mock_to_disk_singlemet, attr), msg

--- a/lsstdesc_diffsky/write_mock_to_disk_singlemet.py
+++ b/lsstdesc_diffsky/write_mock_to_disk_singlemet.py
@@ -1,0 +1,1709 @@
+"""
+write_mock_to_disk.py
+=====================
+Main module for production of mock galaxy catalogs for LSST DESC.
+"""
+import gc
+import os
+import re
+import threading
+import warnings
+from time import time
+
+import h5py
+import numpy as np
+import psutil
+from astropy.cosmology import WMAP7, FlatLambdaCDM
+from astropy.table import Table, vstack
+from astropy.utils.misc import NumpyRNGContext
+from diffstar.defaults import FB
+from diffstar.sfh import sfh_galpop
+
+# SED generation
+from dsps.data_loaders import load_ssp_templates
+from dsps.metallicity.mzr import DEFAULT_MET_PDICT
+from galsampler import crossmatch
+from galsampler.galmatch import galsample
+from halotools.empirical_models import halo_mass_to_halo_radius
+
+# Galsampler
+from halotools.utils.value_added_halo_table_functions import compute_uber_hostid
+from halotools.utils.vector_utilities import normalized_vectors
+from jax import random as jran
+
+from .black_hole_modeling.black_hole_accretion_rate import monte_carlo_bh_acc_rate
+from .black_hole_modeling.black_hole_mass import monte_carlo_black_hole_mass
+from .defaults import CosmoParams
+from .diffstarpop.mc_diffstar import mc_diffstarpop
+from .dspspop.boris_dust import DEFAULT_U_PARAMS as DEFAULT_BORIS_U_PARAMS
+from .dspspop.burstshapepop import DEFAULT_BURSTSHAPE_U_PARAMS
+from .dspspop.dust_deltapop import DEFAULT_DUST_DELTA_U_PARAMS
+from .dspspop.lgavpop import DEFAULT_LGAV_U_PARAMS
+from .dspspop.lgfburstpop import DEFAULT_LGFBURST_U_PARAMS
+from .ellipticity_modeling.ellipticity_model import monte_carlo_ellipticity_bulge_disk
+
+# Halo shapes
+from .halo_information.get_fof_halo_shapes import get_halo_shapes, get_matched_shapes
+
+# Synthetics
+from .halo_information.get_healpix_cutout_info import get_snap_redshift_min
+from .pecZ import pecZ
+from .photometry.get_SFH_from_params import (
+    get_diff_params,
+    get_log_safe_ssfr,
+    get_logsm_sfr_obs,
+)
+from .photometry.load_filter_data import assemble_filter_data, get_filter_wave_trans
+from .photometry.photometry_lc_interp import get_diffsky_sed_info
+from .photometry.precompute_ssp_tables import (
+    precompute_ssp_obsmags_on_z_table,
+    precompute_ssp_restmags,
+)
+
+# Additional catalog properties
+from .size_modeling.zhang_yang17 import (
+    mc_size_vs_luminosity_early_type,
+    mc_size_vs_luminosity_late_type,
+)
+from .synthetic_subhalos.extend_subhalo_mpeak_range import (
+    create_synthetic_lowmass_mock_with_centrals,
+    map_mstar_onto_lowmass_extension,
+)
+from .synthetic_subhalos.synthetic_cluster_satellites import (
+    model_synthetic_cluster_satellites,
+)
+from .synthetic_subhalos.synthetic_lowmass_subhalos import synthetic_logmpeak
+from .triaxial_satellite_distributions.axis_ratio_model import monte_carlo_halo_shapes
+from .triaxial_satellite_distributions.monte_carlo_triaxial_profile import (
+    generate_triaxial_satellite_distribution,
+)
+
+fof_halo_mass = "fof_halo_mass"
+# fof halo mass in healpix cutouts
+fof_mass = "fof_mass"
+mass = "mass"
+fof_max = 14.5
+sod_mass = "sod_mass"
+m_particle_1000 = 1.85e12
+
+Nside_sky = 2048  # fine pixelization for determining sky area
+
+# halo id offsets
+# offset to generate unique id for cutouts and snapshots
+cutout_id_offset_halo = int(1e3)
+# offset to guarantee unique halo ids across cutout files and snapshots
+halo_id_offset = int(1e8)
+
+# galaxy id offsets for non image-sim catalogs (eg. 5000 sq. deg.)
+cutout_id_offset = int(1e9)
+z_offsets_not_im = {"32": [0, 1e8, 2e8, 3e8]}
+
+# constants to determine synthetic number density
+Ntotal_synthetics = 1932058570  # total number of synthetic galaxies in cosmoDC2_image
+nhpx_total = float(131)  # number of healpixels in image area
+snapshot_min = 121
+# specify edges of octant
+volume_minx = 0.0
+volume_miny = 0.0
+volume_maxz = 0.0
+
+__all__ = (
+    "write_umachine_healpix_mock_to_disk",
+    "build_output_snapshot_mock",
+    "write_output_mock_to_disk",
+)
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+def write_umachine_healpix_mock_to_disk(
+    umachine_mstar_ssfr_mock_fname_list,
+    healpix_data,
+    snapshots,
+    output_color_mock_fname,
+    shape_dir,
+    redshift_list,
+    commit_hash,
+    SED_pars={},
+    cosmological_params={},
+    synthetic_params={},
+    shear_params={},
+    versionMajor=0,
+    versionMinor=1,
+    versionMinorMinor=0,
+    Nside=32,
+    mstar_min=7e6,
+    z2ts={},
+    Lbox=3000.0,
+    num_synthetic_gal_ratio=1.0,
+    mass_match_noise=0.1,
+):
+    """
+    GalSample the UM mock into the lightcone healpix cutout,
+    compute the SEDs using DSPS and
+    write the healpix mock to disk.
+
+    Parameters
+    ----------
+    umachine_mstar_ssfr_mock_fname_list : list
+        List of length num_snaps storing the absolute path to the
+        value-added UniverseMachine snapshot mock
+
+    healpix_data : <HDF5 file>
+        Pointer to open hdf5 file for the lightcone healpix cutout
+        source halos into which UniverseMachine will be GalSampled
+
+    snapshots : list
+        List of snapshots in lightcone healpix cutout
+
+    output_color_mock_fname : string
+        Absolute path to the output healpix mock
+
+    shape_dir: string
+        Directory storing files with halo-shape information
+
+    redshift_list : list
+        List of length num_snaps storing the value of the redshifts
+        in the target halo lightcone cutout
+
+    commit_hash : string
+        Commit hash of the version of the cosmodc2 repo used when
+        calling this function.
+
+        After updating the code repo to the desired version,
+        the commit_hash can be determined by navigating to the root
+        directory and typing ``git log --pretty=format:'%h' -n 1``
+
+    synthetic_params: dict contains values for
+        skip_synthetics: boolean
+        Flag to control if ultra-faint synthetics are added to mock
+        synthetic_halo_minimum_mass: float
+        Minimum value of log_10 of synthetic halo mass
+        num_synthetic_gal_ratio: float
+        Ratio to control number of synthetic galaxies generated
+        randomize_redshift_synthetic: boolean
+        Flag to control if noise is added to redshifts in UM snapshot
+
+    SED_pars: dict containing values for SED choices read in from configuration file
+        values supplied by calling script
+
+    shear_params: dict containing values for shear choices
+        add_dummy_shears: boolean
+
+    mstar_min: stellar mass cut for synthetic galaxies (not used in image simulations)
+
+    mass_match_noise: noise added to log of source halo masses to randomize the match
+        to target halos
+
+    versionMajor: int
+        major version number
+
+    versionMinor: int
+        minor version number
+
+    versionMinorMinor: int
+        minor.minor version number
+
+    Returns
+    -------
+    None
+
+    """
+
+    from .constants import SED_params
+
+    output_mock = {}
+    gen = zip(umachine_mstar_ssfr_mock_fname_list, redshift_list, snapshots)
+    start_time = time()
+    process = psutil.Process(os.getpid())
+
+    assert len(cosmological_params) > 0, "No cosmology parameters supplied"
+    H0 = cosmological_params["H0"]
+    OmegaM = cosmological_params["OmegaM"]
+    OmegaB = cosmological_params["OmegaB"]
+    w0 = cosmological_params["w0"]
+    wa = cosmological_params["wa"]
+    print(
+        "Cosmology Parameters:\n",
+        "H0: {:.2g}, OmegaM: {:.3g}, OmegaB: {:.3g}\n".format(H0, OmegaM, OmegaB),
+        "w0: {:.1g} wa: {:.1g}".format(w0, wa),
+    )
+
+    cosmology = FlatLambdaCDM(H0=H0, Om0=OmegaM, Ob0=OmegaB)
+
+    #  determine number of healpix cutout to use as offset for galaxy ids
+    output_mock_basename = os.path.basename(output_color_mock_fname)
+    file_ids = [
+        int(d) for d in re.findall(r"\d+", os.path.splitext(output_mock_basename)[0])
+    ]
+
+    cutout_number_true = file_ids[-1]
+    z_range_id = file_ids[-3]  # 3rd-last digits in filename
+
+    cutout_number = cutout_number_true  # used for output
+    galaxy_id_offset = int(
+        cutout_number_true * cutout_id_offset + z_offsets_not_im[str(Nside)][z_range_id]
+    )
+    halo_id_cutout_offset = int(cutout_number_true * cutout_id_offset_halo)
+
+    #  determine seed from output filename
+    seed = get_random_seed(output_mock_basename)
+
+    #  determine maximum redshift and volume covered by catalog
+    redshift_max = [float(k) for k, v in z2ts.items() if int(v) == snapshot_min][0]
+    Vtotal = cosmology.comoving_volume(redshift_max).value
+
+    # determine total number of synthetic galaxies for arbitrary healpixel for
+    # full z range
+    synthetic_number = int(Ntotal_synthetics / nhpx_total)
+    #  number for healpixels straddling the edge of the octant will be adjusted later
+    # initialize previous redshift for computing synthetic galaxy distributions
+    previous_redshift = get_snap_redshift_min(z2ts, snapshots)
+
+    #  initialize book-keeping variables
+    fof_halo_mass_max = 0.0
+    Ngals_total = 0
+
+    print("\nStarting snapshot processing")
+    print("Using initial seed = {}".format(seed))
+    print("Using nside = {}".format(Nside))
+    print("Maximum redshift for catalog = {}".format(redshift_max))
+    print("Minimum redshift for catalog = {}".format(previous_redshift))
+    print(
+        "Writing catalog version number {}.{}.{}".format(
+            versionMajor, versionMinor, versionMinorMinor
+        )
+    )
+    print("\nUsing halo-id offset = {}".format(halo_id_offset))
+    print(
+        "Using galaxy-id offset = {} for cutout number {}".format(
+            galaxy_id_offset, cutout_number_true
+        )
+    )
+
+    if synthetic_params and not synthetic_params["skip_synthetics"]:
+        synthetic_halo_minimum_mass = synthetic_params["synthetic_halo_minimum_mass"]
+        synthetic_number = synthetic_params["synthetic_number"]
+        randomize_redshift_synthetic = synthetic_params["randomize_redshift_synthetic"]
+        print("Synthetic-halo minimum mass =  {}".format(synthetic_halo_minimum_mass))
+        print("Number of synthetic ultra-faint galaxies = {}".format(synthetic_number))
+        print("Randomize synthetic redshifts = {}".format(randomize_redshift_synthetic))
+    else:
+        print("Not adding synthetic galaxies")
+
+    # initialize SED parameters
+    if SED_pars:
+        # save any supplied parameters from function call
+        for k, v in SED_pars.items():
+            SED_params[k] = v
+
+    T0 = cosmology.age(SED_params["z0"]).value
+    SED_params["LGT0"] = np.log10(T0)
+    print(
+        "\nUsing SED parameters:\n...{}".format(
+            ",\n...".join([": ".join([k, str(v)]) for k, v in SED_params.items()])
+        )
+    )
+
+    dsps_data_DRN = SED_params["dsps_data_dirname"]
+    dsps_data_fn = SED_params["dsps_data_filename"]
+    # get ssp_wave, ssp_flux, lg_met, lg_age_gyr
+    ssp_data = load_ssp_templates(os.path.join(dsps_data_DRN, dsps_data_fn))
+    ssp_wave = ssp_data.ssp_wave
+    ssp_flux = ssp_data.ssp_flux
+    filter_data = assemble_filter_data(dsps_data_DRN, SED_params["filters"])
+    filter_waves, filter_trans, filter_keys = get_filter_wave_trans(filter_data)
+    print(
+        "\nUsing filters and bands: {} ({} bands)".format(
+            ", ".join(filter_keys), len(filter_keys)
+        )
+    )
+
+    # generate precomputed ssp tables
+    min_snap = 0 if len(healpix_data[snapshots[0]]["a"]) > 0 else 1
+    zmin = 1.0 / np.max(healpix_data[snapshots[min_snap]]["a"][()]) - 1.0
+    zmax = 1.0 / np.min(healpix_data[snapshots[-1]]["a"][()]) - 1.0
+    dz = float(SED_params["dz"])
+    z_min = zmin - dz if (zmin - dz) > 0 else zmin / 2  # ensure z_min is > 0
+    z_max = zmax + dz
+    n_z_table = int(np.ceil((z_max - z_min) / dz))
+    ssp_z_table = np.linspace(z_min, z_max, n_z_table)
+    msg = "\nComputing ssp tables for {} z values: {:.2f} < z < {:.2f} (dz={:.2f})\n"
+    print(msg.format(n_z_table, z_min, z_max, dz))
+    ssp_restmag_table = precompute_ssp_restmags(
+        ssp_wave, ssp_flux, filter_waves, filter_trans
+    )
+    ssp_obsmag_table = precompute_ssp_obsmags_on_z_table(
+        ssp_wave,
+        ssp_flux,
+        filter_waves,
+        filter_trans,
+        ssp_z_table,
+        OmegaM,
+        cosmological_params["w0"],
+        cosmological_params["wa"],
+        H0 / 100.0,
+    )
+
+    # save in SED_params for passing to other modules
+    SED_params["ssp_z_table"] = ssp_z_table
+    SED_params["ssp_lgmet"] = ssp_data.ssp_lgmet
+    SED_params["ssp_lg_age_gyr"] = ssp_data.ssp_lg_age_gyr
+    SED_params["ssp_restmag_table"] = ssp_restmag_table
+    SED_params["ssp_obsmag_table"] = ssp_obsmag_table
+    SED_params["filter_keys"] = filter_keys
+    SED_params["filter_waves"] = filter_waves
+    SED_params["filter_trans"] = filter_trans
+
+    for k in SED_params["xkeys"]:
+        dims = (
+            SED_params[k].shape
+            if not isinstance(SED_params[k], list)
+            else len(SED_params[k])
+        )
+        print("...Saving {} to SED_params with shape: {}".format(k, dims))
+
+    default_list = [k for k in SED_params.values() if type(k) is str and "default" in k]
+    for k in default_list:  # placeholder for better code
+        SED_params["lgfburst_pop_u_params"] = DEFAULT_LGFBURST_U_PARAMS
+        SED_params["burstshapepop_u_params"] = DEFAULT_BURSTSHAPE_U_PARAMS
+        SED_params["lgav_dust_u_params"] = DEFAULT_LGAV_U_PARAMS
+        SED_params["dust_delta_u_params"] = DEFAULT_DUST_DELTA_U_PARAMS
+        SED_params["fracuno_pop_u_params"] = DEFAULT_BORIS_U_PARAMS
+        SED_params["lgmet_params"] = list(DEFAULT_MET_PDICT.values())
+
+    roman_rubin_list = [
+        k.split("roman_rubin_2023/")[1]
+        for k in SED_params.values()
+        if type(k) is str and "roman_rubin" in k
+    ]
+
+    for k in roman_rubin_list:
+        if "lgfburst_u_params.txt" in k:
+            SED_params["lgfburst_pop_u_params"] = get_sed_model_params(
+                SED_params["param_data_dirname"], SED_params["lgfburst_fname"]
+            )
+        if "burstshape_u_params.txt" in k:
+            SED_params["burstshapepop_u_params"] = get_sed_model_params(
+                SED_params["param_data_dirname"], SED_params["burstshape_fname"]
+            )
+        if "lgav_dust_u_params.txt" in k:
+            SED_params["lgav_dust_u_params"] = get_sed_model_params(
+                SED_params["param_data_dirname"], SED_params["lgav_dust_fname"]
+            )
+        if "delta_dust_u_params.txt" in k:
+            SED_params["delta_dust_u_params"] = get_sed_model_params(
+                SED_params["param_data_dirname"], SED_params["delta_dust_fname"]
+            )
+        if "funo_dust_u_params.txt" in k:
+            SED_params["fracuno_pop_u_params"] = get_sed_model_params(
+                SED_params["param_data_dirname"], SED_params["fracuno_pop_fname"]
+            )
+        if "lgmet_params.txt" in k:
+            SED_params["lgmet_params"] = get_sed_model_params(
+                SED_params["param_data_dirname"], SED_params["lgmet_fname"]
+            )
+
+    print()
+    model_keys = [k for k in SED_params.keys() if "_model" in k]
+    for key in model_keys:
+        # parse column name to extract filter, frame and band
+        _res = SED_params[key].split("_")
+        if len(_res) >= 2:
+            filt_req = SED_params[key].split("_")[0]
+            frame_req = SED_params[key].split("_")[1]
+            band_req = SED_params[key].split("_")[-1].lower()
+            model_req = [
+                k for k in SED_params["filter_keys"] if filt_req in k and band_req in k
+            ]
+            if len(model_req) == 1 and frame_req in SED_params["frames"]:
+                print("...Using {} for galaxy-{}".format(SED_params[key], key))
+            else:
+                print("...{} not available for galaxy-{}".format(SED_params[key], key))
+                SED_params[key] = None  # filter not available; overwrite key
+        else:
+            if "skip" not in SED_params[key]:
+                print(
+                    "...incorrect option {} for galaxy-{}".format(SED_params[key], key)
+                )
+            print("...Skipping galaxy-{}".format(key))
+            SED_params[key] = None  # filter not available; overwrite key
+
+    t_table = np.linspace(SED_params["t_table_0"], T0, SED_params["N_t_table"])
+    SED_params["t_table"] = t_table
+
+    for a, b, c in gen:
+        umachine_mock_fname = a
+        redshift = b
+        snapshot = c
+        halo_unique_id = int(halo_id_cutout_offset + int(snapshot))
+        print(
+            "\n...Using halo_unique id = {} for snapshot {}".format(
+                halo_unique_id, snapshot
+            )
+        )
+
+        new_time_stamp = time()
+
+        #  seed should be changed for each new shell
+        seed = seed + 2
+
+        #  check for halos in healpixel
+        if len(healpix_data[snapshot]["id"]) == 0:
+            output_mock[snapshot] = {}
+            print("\n...skipping empty snapshot {}".format(snapshot))
+            continue
+
+        #  Get galaxy properties from UM catalogs and target halo properties
+        print("\n...loading z = {0:.2f} galaxy catalog into memory".format(redshift))
+        mock = Table.read(umachine_mock_fname, path="data")
+        print(".....Number of available UM galaxies: {}".format(len(mock)))
+        # print('.....UM catalog colnames: {}'.format(', '.join(mock.colnames)))
+
+        # Assemble table of target halos
+        target_halos = get_astropy_table(
+            healpix_data[snapshot], halo_unique_id=halo_unique_id
+        )
+        fof_halo_mass_max = max(
+            np.max(target_halos[fof_halo_mass].quantity.value), fof_halo_mass_max
+        )
+
+        ################################################################################
+        # generate halo shapes
+        ################################################################################
+        print("\n...Generating halo shapes")
+        b_to_a, c_to_a, e, p = monte_carlo_halo_shapes(
+            np.log10(target_halos[fof_halo_mass])
+        )
+        target_halos["halo_ellipticity"] = e
+        target_halos["halo_prolaticity"] = p
+        spherical_halo_radius = halo_mass_to_halo_radius(
+            target_halos[fof_halo_mass], WMAP7, redshift, "vir"
+        )
+        target_halos["axis_A_length"] = (
+            1.5 * spherical_halo_radius
+        )  # crude fix for B and C shrinking
+        target_halos["axis_B_length"] = b_to_a * target_halos["axis_A_length"]
+        target_halos["axis_C_length"] = c_to_a * target_halos["axis_A_length"]
+
+        nvectors = len(target_halos)
+        rng = np.random.RandomState(seed)
+        random_vectors = rng.uniform(-1, 1, nvectors * 3).reshape((nvectors, 3))
+        axis_A = normalized_vectors(random_vectors) * target_halos[
+            "axis_A_length"
+        ].reshape((-1, 1))
+        target_halos["axis_A_x"] = axis_A[:, 0]
+        target_halos["axis_A_y"] = axis_A[:, 1]
+        target_halos["axis_A_z"] = axis_A[:, 2]
+        # now add halo shape information for those halos with matches in shape files
+        print("\n...Matching halo shapes for selected halos")
+        shapes = get_halo_shapes(
+            snapshot,
+            target_halos["fof_halo_id"],
+            target_halos["lightcone_replication"],
+            shape_dir,
+        )
+        if shapes:
+            target_halos = get_matched_shapes(
+                shapes, target_halos, rep_key="lightcone_replication"
+            )
+
+        ################################################################################
+        #  Galsampler - For every target halo,
+        #               find a source halo with closely matching mass
+        ################################################################################
+        print("\n...Finding halo--halo correspondence with GalSampler")
+
+        #  Set up target and source halo arrays for indices and masses
+        target_halo_ids = target_halos["halo_id"]
+        log_target_mass = np.log10(target_halos[fof_halo_mass])
+        # Ensure that mock uses uber hostid
+        mock.rename_column("hostid", "uber_hostid")
+        upid, uber_hostid, _ = compute_uber_hostid(mock["upid"], mock["halo_id"])
+        if not np.array_equal(mock["upid"], upid):
+            print(".....overwriting upid with corrected upid")
+            mock["upid"] = upid
+        if not np.array_equal(mock["uber_hostid"], uber_hostid):
+            print(".....overwriting hostid with corrected uber hostid")
+            mock["uber_hostid"] = uber_hostid
+        cenmask = mock["upid"] == -1
+        # match to host halos not subhalos
+        source_halo_ids = mock["uber_hostid"][cenmask]
+        assert len(np.unique(source_halo_ids)) == len(
+            source_halo_ids
+        ), "Source halo ids not unique"
+
+        source_galaxies_host_halo_id = mock["uber_hostid"]
+        log_src_mass = np.log10(mock["mp"][cenmask])
+        #  Add noise to randomize the selections around the closest source halo match
+        noisy_log_src_mass = np.random.normal(loc=log_src_mass, scale=mass_match_noise)
+
+        #  Use GalSampler to calculate the indices of the galaxies that will be selected
+        print("...GalSampling z={0:.2f} galaxies to OuterRim halos".format(redshift))
+        gs_results = galsample(
+            source_galaxies_host_halo_id,
+            source_halo_ids,
+            target_halo_ids,
+            [noisy_log_src_mass],
+            [log_target_mass],
+        )
+
+        ########################################################################
+        # Add synthetic galaxies if requested
+        ########################################################################
+        if not synthetic_params["skip_synthetics"]:
+            mock, synthetic_dict = add_low_mass_synthetic_galaxies(
+                mock,
+                seed,
+                synthetic_halo_minimum_mass,
+                redshift,
+                synthetic_number,
+                randomize_redshift_synthetic,
+                previous_redshift,
+                Vtotal,
+                cosmology,
+                mstar_min,
+            )
+        else:
+            synthetic_dict = {}
+
+        ########################################################################
+        #  Assemble the output mock by snapshot
+        ########################################################################
+
+        print("\n...Building output snapshot mock for snapshot {}".format(snapshot))
+        output_mock[snapshot] = build_output_snapshot_mock(
+            float(redshift),
+            mock,
+            target_halos,
+            gs_results,
+            galaxy_id_offset,
+            synthetic_dict,
+            Nside_sky,
+            cutout_number_true,
+            float(previous_redshift),
+            cosmology,
+            w0,
+            wa,
+            volume_minx=volume_minx,
+            SED_params=SED_params,
+            volume_miny=volume_miny,
+            volume_maxz=volume_maxz,
+            seed=seed,
+            shear_params=shear_params,
+            halo_unique_id=halo_unique_id,
+            redshift_method="galaxy",
+        )
+        galaxy_id_offset = galaxy_id_offset + len(
+            output_mock[snapshot]["galaxy_id"]
+        )  # increment offset
+
+        # check that offset is within index bounds
+        galaxy_id_bound = (
+            cutout_number * cutout_id_offset
+            + z_offsets_not_im[str(Nside)][z_range_id + 1]
+        )
+        if galaxy_id_offset > galaxy_id_bound:
+            print(
+                "...Warning: galaxy_id bound of {} exceeded for snapshot {}".format(
+                    galaxy_id_bound, snapshot
+                )
+            )
+
+        Ngals_total += len(output_mock[snapshot]["galaxy_id"])
+        print(
+            "...Saved {} galaxies to dict".format(
+                len(output_mock[snapshot]["galaxy_id"])
+            )
+        )
+        previous_redshift = redshift  # update for next snap
+
+        # do garbage collection
+        gc.collect()
+
+        time_stamp = time()
+        msg = "\nLightcone-shell runtime = {0:.2f} minutes"
+        print(msg.format((time_stamp - new_time_stamp) / 60.0))
+
+        mem = "Memory usage =  {0:.2f} GB"
+        print(mem.format(process.memory_info().rss / 1.0e9))
+
+        mem = "Thread count =  {}"
+        print(mem.format(threading.active_count()))
+        for env in ["OMP_NUM_THREADS", "MKL_NUM_THREADS", "NUMEXPR_NUM_THREADS"]:
+            print("Checking {} = {}".format(env, os.environ.get(env)))
+
+    ########################################################################
+    #  Write the output mock to disk
+    ########################################################################
+    if len(output_mock) > 0:
+        check_time = time()
+        write_output_mock_to_disk(
+            output_color_mock_fname,
+            output_mock,
+            commit_hash,
+            seed,
+            synthetic_params,
+            cutout_number_true,
+            Nside,
+            cosmology,
+            versionMajor=versionMajor,
+            versionMinor=versionMinor,
+            versionMinorMinor=versionMinorMinor,
+        )
+        print(
+            "...time to write mock to disk = {:.2f} minutes".format(
+                (time() - check_time) / 60.0
+            )
+        )
+
+    print(
+        "Maximum halo mass for {} ={}\n".format(output_mock_basename, fof_halo_mass_max)
+    )
+    print("Number of galaxies for {} ={}\n".format(output_mock_basename, Ngals_total))
+
+    time_stamp = time()
+    msg = "\nEnd-to-end runtime = {0:.2f} minutes\n"
+    print(msg.format((time_stamp - start_time) / 60.0))
+
+
+# reduce max seed by 200 to allow for 60 light-cone shells
+def get_random_seed(filename, seed_max=4294967095):
+    import hashlib
+
+    s = hashlib.md5(filename.encode("utf-8")).hexdigest()
+    seed = int(s, 16)
+
+    #  enforce seed is below seed_max and odd
+    seed = seed % seed_max
+    if seed % 2 == 0:
+        seed = seed + 1
+    return seed
+
+
+def get_volume_factor(redshift, previous_redshift, Vtotal, cosmology):
+    Vshell = (
+        cosmology.comoving_volume(float(redshift)).value
+        - cosmology.comoving_volume(float(previous_redshift)).value
+    )
+    return Vshell / Vtotal
+
+
+def get_sed_model_params(param_dir, param_file):
+    param_filename = os.path.join(param_dir, param_file)
+    with open(param_filename) as fh:
+        params = [x.split() for x in fh.readlines()]
+        print("\nReading model parameters from file {}".format(param_filename))
+    keys = tuple([p[0] for p in params])
+    values = tuple([float(p[1]) for p in params])
+    param_dict = dict(zip(keys, values))
+    for k, v in param_dict.items():
+        print("....{} = {:.4f}".format(k, v))
+
+    return param_dict
+
+
+def get_astropy_table(table_data, halo_unique_id=0, check=False, cosmology=None):
+    """ """
+    t = Table()
+    for k in table_data.keys():
+        t[k] = table_data[k]
+
+    t.rename_column("id", "fof_halo_id")
+    t.rename_column("rot", "lightcone_rotation")
+    t.rename_column("rep", "lightcone_replication")
+    t["halo_redshift"] = 1 / t["a"] - 1.0
+
+    t["halo_id"] = (
+        np.arange(len(table_data["id"])) * halo_id_offset + halo_unique_id
+    ).astype(int)
+
+    #  rename column mass if found
+    if mass in t.colnames:
+        t.rename_column(mass, fof_halo_mass)
+    elif fof_mass in t.colnames:
+        t.rename_column(fof_mass, fof_halo_mass)
+    else:
+        print("  Warning; halo mass or fof_mass not found")
+
+    #  check sod information and clean bad values
+    if sod_mass in t.colnames:
+        mask_valid = t[sod_mass] > 0
+        mask = mask_valid & (t[sod_mass] < m_particle_1000)
+        # overwrite
+        for cn in ["sod_cdelta", "sod_cdelta_error", sod_mass, "sod_radius"]:
+            t[cn][mask] = -1
+
+        if np.count_nonzero(mask) > 0:
+            print(
+                ".....Overwrote {}/{} SOD quantities failing {:.2g} mass cut".format(
+                    np.count_nonzero(mask),
+                    np.count_nonzero(mask_valid),
+                    m_particle_1000,
+                )
+            )
+
+    if check and cosmology is not None:
+        #  compute comoving distance from z and from position
+        r = np.sqrt(t["x"] * t["x"] + t["y"] * t["y"] + t["z"] * t["z"])
+        comoving_distance = (
+            cosmology.comoving_distance(t["halo_redshift"]) * cosmology.H0.value / 100.0
+        )
+        print("r == comoving_distance(z) is {}", np.isclose(r, comoving_distance))
+
+    print(
+        "...Number of target halos to populate with galaxies: {}".format(
+            len(t["halo_id"])
+        )
+    )
+
+    return t
+
+
+def add_low_mass_synthetic_galaxies(
+    mock,
+    seed,
+    synthetic_halo_minimum_mass,
+    redshift,
+    synthetic_number,
+    randomize_redshift_synthetic,
+    previous_redshift,
+    Vtotal,
+    cosmology,
+    mstar_min,
+    use_substeps_synthetic=False,
+    nzdivs=6,
+):
+    #  Correct stellar mass for low-mass subhalos and create synthetic mpeak
+    print(".....correcting low mass mpeak and assigning synthetic mpeak values")
+
+    #  First generate the appropriate number of synthetic galaxies for the snapshot
+    mpeak_synthetic_snapshot = 10 ** synthetic_logmpeak(
+        mock["mpeak"], seed=seed, desired_logm_completeness=synthetic_halo_minimum_mass
+    )
+    print(".....assembling {} synthetic galaxies".format(len(mpeak_synthetic_snapshot)))
+
+    # Add call to map_mstar_onto_lowmass_extension function after
+    # pre-determining low-mass slope
+    print(".....re-assigning low-mass mstar values")
+    new_mstar_real, mstar_synthetic_snapshot = map_mstar_onto_lowmass_extension(
+        mock["mpeak"], mock["obs_sm"], mpeak_synthetic_snapshot
+    )
+    diff = np.equal(new_mstar_real, mock["obs_sm"])
+    print(
+        ".......changed {}/{} M* values; max/min new log(M*) {:.2f}/{:.2f}".format(
+            np.count_nonzero(~diff),
+            len(diff),
+            np.max(np.log10(new_mstar_real[~diff])),
+            np.min(np.log10(new_mstar_real[~diff])),
+        )
+    )
+    mock["obs_sm"] = new_mstar_real
+    mstar_mask = np.isclose(mstar_synthetic_snapshot, 0.0)
+    if np.sum(mstar_mask) > 0:
+        print(
+            ".....Warning: Number of synthetics with zero mstar = {}".format(
+                np.sum(mstar_mask)
+            )
+        )
+
+    #  Assign diffstar parameters to synthetic low-mass galaxies
+    print("TBD: get diffstar parameters for synthetic galaxies")
+
+    #  Now downsample the synthetic galaxies to adjust for volume of lightcone shell
+    #  desired number = synthetic_number*comoving_vol(snapshot)/comoving_vol(healpixel)
+    volume_factor = get_volume_factor(redshift, previous_redshift, Vtotal, cosmology)
+    num_selected_synthetic = int(synthetic_number * volume_factor)
+    num_synthetic_gals_in_snapshot = len(mpeak_synthetic_snapshot)
+    synthetic_indices = np.arange(0, num_synthetic_gals_in_snapshot).astype(int)
+    with NumpyRNGContext(seed):
+        selected_synthetic_indices = np.random.choice(
+            synthetic_indices, size=num_selected_synthetic, replace=False
+        )
+    msg = ".....down-sampling synthetic galaxies with volume factor {} to yield {}"
+    print(
+        "{} selected synthetics".format(
+            msg.format(volume_factor, num_selected_synthetic)
+        )
+    )
+    mstar_synthetic = mstar_synthetic_snapshot[selected_synthetic_indices]
+    #  Apply additional M* cut to reduce number of synthetics for 5000 sq. deg. catalog
+    if mstar_min > 0:
+        mstar_mask = mstar_synthetic > mstar_min
+        msg = ".....removing synthetics with M* < {:.1e} to yield {} total synthetics"
+        print(msg.format(mstar_min, np.count_nonzero(mstar_mask)))
+
+    mstar_synthetic = mstar_synthetic[mstar_mask]
+    mpeak_synthetic = mpeak_synthetic_snapshot[selected_synthetic_indices][mstar_mask]
+    synthetic_dict = dict(
+        mpeak=mpeak_synthetic,
+        obs_sm=mstar_synthetic,
+    )
+
+    return mock, synthetic_dict
+
+
+def build_output_snapshot_mock(
+    snapshot_redshift,
+    umachine,
+    target_halos,
+    gs_results,
+    galaxy_id_offset,
+    synthetic_dict,
+    Nside,
+    cutout_number_true,
+    previous_redshift,
+    cosmology,
+    w0,
+    wa,
+    volume_minx=0.0,
+    volume_miny=0.0,
+    volume_maxz=0.0,
+    SED_params={},
+    seed=41,
+    shear_params={},
+    mah_keys="mah_keys",
+    ms_keys="ms_keys",
+    q_keys="q_keys",
+    mah_pars="mah_params",
+    ms_pars="ms_params",
+    q_pars="q_params",
+    halo_unique_id=0,
+    redshift_method="galaxy",
+    source_galaxy_tag="um_source_galaxy_",
+    bulge_frac="bulge_frac",
+):
+    """
+    Collect the GalSampled snapshot mock into an astropy table
+
+    Parameters
+    ----------
+    snapshot_redshift : float
+        Float of the snapshot redshift
+
+    umachine : astropy.table.Table
+        Astropy Table of shape (num_source_gals, )
+        storing the UniverseMachine snapshot mock
+
+    target_halos : astropy.table.Table
+        Astropy Table of shape (num_target_halos, )
+        storing the target halo catalog
+
+    gs_results: named ntuple
+        Named ntuple returned by galsample containing 3 arrays
+        of shape (num_target_gals, )
+        storing integers valued between [0, num_source_gals)
+
+    commit_hash : string
+        Commit hash of the version of the code repo used when
+        calling this function.
+
+        After updating the code repo to the desired version,
+        the commit_hash can be determined by navigating to the root
+        directory and typing ``git log --pretty=format:'%h' -n 1``
+
+    Returns
+    -------
+    dc2 : astropy.table.Table
+        Astropy Table of shape (num_target_gals, )
+        storing the GalSampled galaxy catalog
+    """
+    dc2 = Table()
+
+    # unpack galsampler results
+    galaxy_indices = gs_results.target_gals_selection_indx
+    target_gals_target_halo_ids = gs_results.target_gals_target_halo_ids
+    target_gals_source_halo_ids = gs_results.target_gals_source_halo_ids
+
+    dc2["source_halo_uber_hostid"] = target_gals_source_halo_ids
+    dc2["target_halo_id"] = target_gals_target_halo_ids
+
+    # save target halo information into mock
+    # compute richness
+    # tgt_unique, tgt_inv, tgt_counts = np.unique(target_gals_target_halo_ids,
+    #                                             return_inverse=True,
+    #                                             return_counts=True)
+    # dc2['richness'] = tgt_counts[tgt_inv]
+    #
+    # Method 1: use unique arrays to get values
+    # hunique, hidx = np.unique(target_halos['halo_id'], return_index=True)
+    # reconstruct mock arrays using target_halos[name][hidx][tgt_inv]
+
+    # Method 2: cross-match to get target halo information
+    idxA, idxB = crossmatch(target_gals_target_halo_ids, target_halos["halo_id"])
+    msg = "target IDs do not match!"
+    assert np.all(dc2["target_halo_id"][idxA] == target_halos["halo_id"][idxB]), msg
+
+    for col in ["lightcone_rotation", "lightcone_replication"]:
+        dc2[col] = 0.0
+        dc2[col][idxA] = target_halos[col][idxB]
+
+    dc2["target_halo_fof_halo_id"] = 0.0
+    dc2["target_halo_redshift"] = 0.0
+    dc2["target_halo_x"] = 0.0
+    dc2["target_halo_y"] = 0.0
+    dc2["target_halo_z"] = 0.0
+    dc2["target_halo_vx"] = 0.0
+    dc2["target_halo_vy"] = 0.0
+    dc2["target_halo_vz"] = 0.0
+
+    dc2["target_halo_fof_halo_id"][idxA] = target_halos["fof_halo_id"][idxB]
+    dc2["target_halo_redshift"][idxA] = target_halos["halo_redshift"][idxB]
+    dc2["target_halo_x"][idxA] = target_halos["x"][idxB]
+    dc2["target_halo_y"][idxA] = target_halos["y"][idxB]
+    dc2["target_halo_z"][idxA] = target_halos["z"][idxB]
+
+    dc2["target_halo_vx"][idxA] = target_halos["vx"][idxB]
+    dc2["target_halo_vy"][idxA] = target_halos["vy"][idxB]
+    dc2["target_halo_vz"][idxA] = target_halos["vz"][idxB]
+
+    dc2["target_halo_mass"] = 0.0
+    dc2["target_halo_mass"][idxA] = target_halos["fof_halo_mass"][idxB]
+
+    dc2["target_halo_ellipticity"] = 0.0
+    dc2["target_halo_ellipticity"][idxA] = target_halos["halo_ellipticity"][idxB]
+
+    dc2["target_halo_prolaticity"] = 0.0
+    dc2["target_halo_prolaticity"][idxA] = target_halos["halo_prolaticity"][idxB]
+
+    dc2["target_halo_axis_A_length"] = 0.0
+    dc2["target_halo_axis_B_length"] = 0.0
+    dc2["target_halo_axis_C_length"] = 0.0
+    dc2["target_halo_axis_A_length"][idxA] = target_halos["axis_A_length"][idxB]
+    dc2["target_halo_axis_B_length"][idxA] = target_halos["axis_B_length"][idxB]
+    dc2["target_halo_axis_C_length"][idxA] = target_halos["axis_C_length"][idxB]
+
+    dc2["target_halo_axis_A_x"] = 0.0
+    dc2["target_halo_axis_A_y"] = 0.0
+    dc2["target_halo_axis_A_z"] = 0.0
+    dc2["target_halo_axis_A_x"][idxA] = target_halos["axis_A_x"][idxB]
+    dc2["target_halo_axis_A_y"][idxA] = target_halos["axis_A_y"][idxB]
+    dc2["target_halo_axis_A_z"][idxA] = target_halos["axis_A_z"][idxB]
+
+    # add SOD information from target_halo table
+    dc2["sod_halo_cdelta"] = 0.0
+    dc2["sod_halo_cdelta_error"] = 0.0
+    dc2["sod_halo_mass"] = 0.0
+    dc2["sod_halo_radius"] = 0.0
+    dc2["sod_halo_cdelta"][idxA] = target_halos["sod_cdelta"][idxB]
+    dc2["sod_halo_cdelta_error"][idxA] = target_halos["sod_cdelta_error"][idxB]
+    dc2["sod_halo_mass"][idxA] = target_halos["sod_mass"][idxB]
+    dc2["sod_halo_radius"][idxA] = target_halos["sod_radius"][idxB]
+
+    #  Here the host_centric_xyz_vxvyvz in umachine should be overwritten
+    #  Then we can associate x <--> A, y <--> B, z <--> C and then apply
+    #  a random rotation
+    #  It will be important to record the true direction of the major axis as a
+    #  stored column
+
+    source_galaxy_prop_keys = (
+        "mp",
+        "vmp",
+        "rvir",
+        "upid",
+        "host_rvir",
+        "host_mp",
+        "host_rvir",
+        "halo_id",
+        "has_fit",
+        "is_main_branch",
+        "obs_sm",
+        "obs_sfr",
+    )
+    source_galaxy_pv_keys = (
+        "host_dx",
+        "host_dy",
+        "host_dz",
+        "host_dvx",
+        "host_dvy",
+        "host_dvz",
+    )
+    # check for no-fit replacement
+    if "nofit_replace" in umachine.colnames:
+        source_galaxy_prop_keys = source_galaxy_prop_keys + ("nofit_replace",)
+    SFH_param_keys = SED_params[mah_keys] + SED_params[ms_keys] + SED_params[q_keys]
+
+    source_galaxy_keys = (
+        source_galaxy_pv_keys + source_galaxy_prop_keys + tuple(SFH_param_keys)
+    )
+
+    for key in source_galaxy_keys:
+        newkey = source_galaxy_tag + key if key in source_galaxy_prop_keys else key
+        try:
+            dc2[newkey] = umachine[key][galaxy_indices]
+        except KeyError:
+            msg = (
+                "The build_output_snapshot_mock function was passed a umachine mock\n"
+                "that does not contain the ``{0}`` key"
+            )
+            raise KeyError(msg.format(key))
+
+    # remap M* for high-mass halos
+    max_umachine_halo_mass = np.max(umachine["mp"])
+    ultra_high_mvir_halo_mask = (dc2[source_galaxy_tag + "upid"] == -1) & (
+        dc2["target_halo_mass"] > max_umachine_halo_mass
+    )
+    num_to_remap = np.count_nonzero(ultra_high_mvir_halo_mask)
+    if num_to_remap > 0:
+        print(
+            ".....remapping stellar mass of {0} BCGs in ultra-massive halos".format(
+                num_to_remap
+            )
+        )
+
+        halo_mass_array = dc2["target_halo_mass"][ultra_high_mvir_halo_mask]
+        mpeak_array = dc2[source_galaxy_tag + "mp"][ultra_high_mvir_halo_mask]
+        mhalo_ratio = halo_mass_array / mpeak_array
+        mstar_array = dc2[source_galaxy_tag + "obs_sm"][ultra_high_mvir_halo_mask]
+        redshift_array = dc2["target_halo_redshift"][ultra_high_mvir_halo_mask]
+        upid_array = dc2[source_galaxy_tag + "upid"][ultra_high_mvir_halo_mask]
+
+        assert np.shape(halo_mass_array) == (
+            num_to_remap,
+        ), "halo_mass_array has shape = {0}".format(np.shape(halo_mass_array))
+        assert np.shape(mstar_array) == (
+            num_to_remap,
+        ), "mstar_array has shape = {0}".format(np.shape(mstar_array))
+        assert np.shape(redshift_array) == (
+            num_to_remap,
+        ), "redshift_array has shape = {0}".format(np.shape(redshift_array))
+        assert np.shape(upid_array) == (
+            num_to_remap,
+        ), "upid_array has shape = {0}".format(np.shape(upid_array))
+        assert np.all(
+            mhalo_ratio >= 1
+        ), "Bookkeeping error: all values of mhalo_ratio ={0} should be >= 1".format(
+            mhalo_ratio
+        )
+
+        obs_sm_key = source_galaxy_tag + "obs_sm"
+        halo_id_key = source_galaxy_tag + "halo_id"
+        dc2[obs_sm_key][ultra_high_mvir_halo_mask] = mstar_array * (mhalo_ratio**0.5)
+        idx = np.argmax(dc2[obs_sm_key])
+        halo_id_most_massive = dc2[halo_id_key][idx]
+        assert (
+            dc2[obs_sm_key][idx] < 10**13.5
+        ), "halo_id = {0} has stellar mass {1:.3e}".format(
+            halo_id_most_massive, dc2[obs_sm_key][idx]
+        )
+
+    # generate triaxial satellite distributions based on halo shapes
+    satmask = dc2[source_galaxy_tag + "upid"] != -1
+    nsats = np.count_nonzero(satmask)
+    host_conc = 5.0
+    if nsats > 0:
+        host_Ax = dc2["target_halo_axis_A_x"][satmask]
+        host_Ay = dc2["target_halo_axis_A_y"][satmask]
+        host_Az = dc2["target_halo_axis_A_z"][satmask]
+        b_to_a = (
+            dc2["target_halo_axis_B_length"][satmask]
+            / dc2["target_halo_axis_A_length"][satmask]
+        )
+        c_to_a = (
+            dc2["target_halo_axis_C_length"][satmask]
+            / dc2["target_halo_axis_A_length"][satmask]
+        )
+        host_dx, host_dy, host_dz = generate_triaxial_satellite_distribution(
+            host_conc, host_Ax, host_Ay, host_Az, b_to_a, c_to_a
+        )
+        dc2["host_dx"][satmask] = host_dx
+        dc2["host_dy"][satmask] = host_dy
+        dc2["host_dz"][satmask] = host_dz
+
+    # save positions and velocities
+    dc2["x"] = dc2["target_halo_x"] + dc2["host_dx"]
+    dc2["vx"] = dc2["target_halo_vx"] + dc2["host_dvx"]
+
+    dc2["y"] = dc2["target_halo_y"] + dc2["host_dy"]
+    dc2["vy"] = dc2["target_halo_vy"] + dc2["host_dvy"]
+
+    dc2["z"] = dc2["target_halo_z"] + dc2["host_dz"]
+    dc2["vz"] = dc2["target_halo_vz"] + dc2["host_dvz"]
+
+    print(
+        ".....number of galaxies before adding synthetic satellites = {}".format(
+            len(dc2[source_galaxy_tag + "halo_id"])
+        )
+    )
+
+    # add synthetic cluster galaxies
+    fake_cluster_sats = model_synthetic_cluster_satellites(
+        dc2,
+        Lbox=0.0,
+        host_conc=host_conc,
+        SFH_keys=list(SFH_param_keys),
+        source_halo_mass_key=source_galaxy_tag + "host_mp",
+        source_halo_id_key=source_galaxy_tag + "halo_id",
+        upid_key=source_galaxy_tag + "upid",
+        tri_axial_positions=True,
+        source_galaxy_tag=source_galaxy_tag,
+    )  # turn off periodicity
+    if len(fake_cluster_sats) > 0:
+        print(".....generating and stacking synthetic cluster satellites")
+        check_time = time()
+        dc2 = vstack((dc2, fake_cluster_sats))
+        print(
+            ".....time to create {} galaxies in fake_cluster_sats = {:.2f} secs".format(
+                len(fake_cluster_sats["target_halo_id"]), time() - check_time
+            )
+        )
+    else:
+        print(".....no synthetic cluster satellites required")
+
+    # generate redshifts, ra and dec
+    dc2 = get_sky_coords(
+        dc2, cosmology, redshift_method, source_galaxy_tag=source_galaxy_tag
+    )
+
+    # save number of galaxies in shell
+    Ngals = len(dc2["target_halo_id"])
+
+    # generate mags
+    dc2 = generate_SEDs(
+        dc2,
+        SED_params,
+        cosmology,
+        w0,
+        wa,
+        seed,
+        snapshot_redshift,
+        mah_keys,
+        ms_keys,
+        q_keys,
+        Ngals,
+        mah_pars=mah_pars,
+        ms_pars=ms_pars,
+        q_pars=q_pars,
+        source_galaxy_tag=source_galaxy_tag,
+    )
+
+    # Add low-mass synthetic galaxies
+    if synthetic_dict and len(synthetic_dict["mp"]) > 0:
+        check_time = time()
+        lowmass_mock = create_synthetic_lowmass_mock_with_centrals(
+            umachine,
+            dc2,
+            synthetic_dict,
+            previous_redshift,
+            snapshot_redshift,
+            cosmology,
+            Nside=Nside,
+            cutout_id=cutout_number_true,
+            H0=cosmology.H0.value,
+            volume_minx=volume_minx,
+            volume_miny=volume_miny,
+            volume_maxz=volume_maxz,
+            halo_id_offset=halo_id_offset,
+            halo_unique_id=halo_unique_id,
+        )
+        lowmass_mock = get_sky_coords(lowmass_mock, cosmology, redshift_method="halo")
+
+        if len(lowmass_mock) > 0:
+            # astropy vstack pads missing values with zeros in lowmass_mock
+            dc2 = vstack((dc2, lowmass_mock))
+            msg = ".....time to create {} galaxies in lowmass_mock = {:.2f} secs"
+            print(
+                msg.format(
+                    len(lowmass_mock["target_halo_id"]),
+                    time() - check_time,
+                )
+            )
+
+    # Add shears and magnification
+    if shear_params["add_dummy_shears"]:
+        print("\n.....adding dummy shears and magnification")
+        dc2["shear1"] = np.zeros(Ngals, dtype="f4")
+        dc2["shear2"] = np.zeros(Ngals, dtype="f4")
+        dc2["magnification"] = np.ones(Ngals, dtype="f4")
+        dc2["convergence"] = np.zeros(Ngals, dtype="f4")
+    else:
+        print("\n.....TBD: add real shears")
+
+    # Add auxiliary quantities for sizes and ellipticities and black-hole masses
+    # TBD Need dc2['bulge_to_total_ratio'] for some quantities
+
+    if SED_params["size_model_mag"]:
+        size_disk, size_sphere, arcsec_per_kpc = get_galaxy_sizes(
+            dc2[SED_params["size_model_mag"]], dc2["redshift"], cosmology
+        )
+        dc2["spheroidHalfLightRadius"] = size_sphere
+        dc2["spheroidHalfLightRadiusArcsec"] = size_sphere * arcsec_per_kpc
+        dc2["diskHalfLightRadius"] = size_disk
+        dc2["diskHalfLightRadiusArcsec"] = size_disk * arcsec_per_kpc
+
+    if SED_params["ellipticity_model_mag"]:
+        pos_angle = np.random.uniform(size=Ngals) * np.pi
+        spheroid_ellip_cosmos, disk_ellip_cosmos = monte_carlo_ellipticity_bulge_disk(
+            dc2[SED_params["ellipticity_model_mag"]]
+        )
+        # Returns distortion ellipticity = 1-q^2 / 1+q^2; q=axis ratio
+        spheroid_axis_ratio = np.sqrt(
+            (1 - spheroid_ellip_cosmos) / (1 + spheroid_ellip_cosmos)
+        )
+        disk_axis_ratio = np.sqrt((1 - disk_ellip_cosmos) / (1 + disk_ellip_cosmos))
+        # Calculate ellipticity from the axis ratios using shear ellipticity e =
+        # 1-q / 1+q
+        ellip_disk = (1.0 - disk_axis_ratio) / (1.0 + disk_axis_ratio)
+        ellip_spheroid = (1.0 - spheroid_axis_ratio) / (1.0 + spheroid_axis_ratio)
+        dc2["spheroidAxisRatio"] = np.array(spheroid_axis_ratio, dtype="f4")
+        dc2["spheroidMajorAxisArcsec"] = np.array(
+            dc2["spheroidHalfLightRadiusArcsec"].value, dtype="f4"
+        )
+        dc2["spheroidMinorAxisArcsec"] = np.array(
+            dc2["spheroidHalfLightRadiusArcsec"].value * spheroid_axis_ratio, dtype="f4"
+        )
+        dc2["spheroidEllipticity"] = np.array(ellip_spheroid, dtype="f4")
+        dc2["spheroidEllipticity1"] = np.array(
+            np.cos(2.0 * pos_angle) * ellip_spheroid, dtype="f4"
+        )
+        dc2["spheroidEllipticity2"] = np.array(
+            np.sin(2.0 * pos_angle) * ellip_spheroid, dtype="f4"
+        )
+        dc2["diskAxisRatio"] = np.array(disk_axis_ratio, dtype="f4")
+        dc2["diskMajorAxisArcsec"] = np.array(
+            dc2["diskHalfLightRadiusArcsec"].value, dtype="f4"
+        )
+        dc2["diskMinorAxisArcsec"] = np.array(
+            dc2["diskHalfLightRadiusArcsec"].value * disk_axis_ratio, dtype="f4"
+        )
+        dc2["diskEllipticity"] = np.array(ellip_disk, dtype="f4")
+        dc2["diskEllipticity1"] = np.array(
+            np.cos(2.0 * pos_angle) * ellip_disk, dtype="f4"
+        )
+        dc2["diskEllipticity2"] = np.array(
+            np.sin(2.0 * pos_angle) * ellip_disk, dtype="f4"
+        )
+        dc2["positionAngle"] = np.array(pos_angle * 180.0 / np.pi, dtype="f4")
+        if bulge_frac in dc2.colnames:
+            tot_ellip = (1.0 - dc2[bulge_frac]) * ellip_disk + dc2[
+                bulge_frac
+            ] * ellip_spheroid
+            dc2["totalEllipticity"] = np.array(tot_ellip, dtype="f4")
+            dc2["totalAxisRatio"] = np.array(
+                (1.0 - tot_ellip) / (1.0 + tot_ellip), dtype="f4"
+            )
+            dc2["totalEllipticity1"] = np.array(
+                np.cos(2.0 * pos_angle) * tot_ellip, dtype="f4"
+            )
+            dc2["totalEllipticity2"] = np.array(
+                np.sin(2.0 * pos_angle) * tot_ellip, dtype="f4"
+            )
+            # srsc_indx_disk = 1.0*np.ones(lum_disk.size,dtype='f4')
+            # srsc_indx_sphere = 4.0*np.ones(lum_disk.size,dtype='f4')
+            # srsc_indx_tot = srsc_indx_disk*(1. - dc2['bulge_to_total_ratio'])
+            #                 + srsc_indx_sphere*dc2['bulge_to_total_ratio']
+            # dc2['diskSersicIndex'] = srsc_indx_disk
+            # dc2['spheroidSersicIndex'] = srsc_indx_sphere
+            # dc2['totalSersicIndex'] = srsc_indx_tot
+
+    if SED_params["black_hole_model"]:
+        # TBD update this
+        # percentile_sfr = dc2[source_galaxy_tag + "percentile_sfr"]
+        percentile_sfr = np.random.uniform(size=Ngals)
+        dc2["bulge_stellar_mass"] = dc2[bulge_frac] * np.power(10, dc2["logsm_obs"])
+        dc2["blackHoleMass"] = monte_carlo_black_hole_mass(dc2["bulge_stellar_mass"])
+        eddington_ratio, bh_acc_rate = monte_carlo_bh_acc_rate(
+            snapshot_redshift, dc2["blackHoleMass"], percentile_sfr
+        )
+        dc2["blackHoleAccretionRate"] = bh_acc_rate * 1e9
+        dc2["blackHoleEddingtonRatio"] = eddington_ratio
+
+    # Add column for redshifts including peculiar velocities
+    _, z_obs, v_pec, _, _, _, _ = pecZ(
+        dc2["x"], dc2["y"], dc2["z"], dc2["vx"], dc2["vy"], dc2["vz"], dc2["redshift"]
+    )
+
+    dc2["peculiarVelocity"] = np.array(v_pec, dtype="f4")
+    dc2.rename_column("redshift", "redshiftHubble")
+    dc2["redshift"] = z_obs
+
+    # Galaxy ids
+    dc2["galaxy_id"] = np.arange(
+        galaxy_id_offset, galaxy_id_offset + len(dc2["target_halo_id"])
+    ).astype(int)
+    print(
+        "\n.....Min and max galaxy_id = {} -> {}".format(
+            np.min(dc2["galaxy_id"]), np.max(dc2["galaxy_id"])
+        )
+    )
+
+    # convert table to dict
+    check_time = time()
+    output_dc2 = {}
+    for k in dc2.keys():
+        output_dc2[k] = dc2[k].quantity.value
+
+    print(".....time to new dict = {:.4f} secs".format(time() - check_time))
+
+    return output_dc2
+
+
+def generate_SEDs(
+    dc2,
+    SED_params,
+    cosmology,
+    w0,
+    wa,
+    seed,
+    snapshot_redshift,
+    mah_keys,
+    ms_keys,
+    q_keys,
+    Ngals,
+    mah_pars="mah_params",
+    ms_pars="ms_params",
+    q_pars="q_params",
+    source_galaxy_tag="source_galaxy",
+):
+    check = validate_SED_params(
+        SED_params,
+        mah_keys=mah_keys,
+        ms_keys=ms_keys,
+        q_keys=q_keys,
+    )
+    assert check, "SED_params does not have required contents"
+
+    dc2 = substitute_SFH_fit_failures(
+        dc2,
+        SED_params,
+        source_galaxy_tag,
+        seed,
+        cosmology,
+        snapshot_redshift,
+        mah_keys=mah_keys,
+        ms_keys=ms_keys,
+        q_keys=q_keys,
+    )
+    """
+    assemble params from UM matches and compute SFH
+    """
+    _res = get_diff_params(
+        dc2,
+        mah_keys=SED_params[mah_keys],
+        ms_keys=SED_params[ms_keys],
+        q_keys=SED_params[q_keys],
+    )
+    mah_params, ms_params, q_params = _res
+    t_obs = cosmology.age(dc2["redshift"]).value
+
+    # get SFH table and observed stellar mass
+    sfh_table = sfh_galpop(
+        SED_params["t_table"],
+        mah_params,
+        ms_params,
+        q_params,
+        lgt0=SED_params["LGT0"],
+        fb=FB,
+    )
+    logsm_obs, sfr_obs = get_logsm_sfr_obs(sfh_table, t_obs, SED_params["t_table"])
+    dc2["logsm_obs"] = logsm_obs
+    dc2["sfr"] = sfr_obs
+    log_ssfr = get_log_safe_ssfr(logsm_obs, sfr_obs)
+    dc2["log_ssfr"] = log_ssfr
+
+    fb = cosmology.Ob0 / cosmology.Om0
+    cosmo_params = CosmoParams(cosmology.Om0, w0, wa, cosmology.H0.value / 100, fb)
+
+    # compute SEDs
+    ran_key = jran.PRNGKey(seed)
+    _res = get_diffsky_sed_info(
+        ran_key,
+        dc2["redshift"],
+        mah_params,
+        ms_params,
+        q_params,
+        SED_params["ssp_z_table"],
+        SED_params["ssp_restmag_table"],
+        SED_params["ssp_obsmag_table"],
+        SED_params["ssp_lgmet"],
+        SED_params["ssp_lg_age_gyr"],
+        SED_params["t_table"],
+        SED_params["filter_waves"],
+        SED_params["filter_trans"],
+        SED_params["filter_waves"],
+        SED_params["filter_trans"],
+        np.array(list(SED_params["lgfburst_pop_u_params"].values())),
+        np.array(list(SED_params["burstshapepop_u_params"].values())),
+        np.array(list(SED_params["lgav_dust_u_params"].values())),
+        np.array(list(SED_params["delta_dust_u_params"].values())),
+        np.array(list(SED_params["fracuno_pop_u_params"].values())),
+        np.array(list(SED_params["lgmet_params"].values())),
+        cosmo_params,
+    )
+
+    # save quantities to DC2
+    dc2 = save_sed_info(dc2, _res, SED_params)
+
+    return dc2
+
+
+def validate_SED_params(
+    SED_params,
+    required=[
+        "use_diffmah_pop",
+        "LGT0",
+        "t_table",
+        "ssp_z_table",
+        "ssp_restmag_table",
+        "ssp_obsmag_table",
+        "ssp_lgmet",
+        "ssp_lg_age_gyr",
+        "t_table",
+        "filter_waves",
+        "filter_trans",
+        "lgfburst_pop_u_params",
+        "burstshapepop_u_params",
+        "lgav_dust_u_params",
+        "delta_dust_u_params",
+        "fracuno_pop_u_params",
+        "lgmet_params",
+    ],
+    mah_keys="mah_keys",
+    ms_keys="ms_keys",
+    q_keys="q_keys",
+):
+    check = True
+    for k in required + [mah_keys] + [ms_keys] + [q_keys]:
+        if k not in SED_params.keys():
+            print(".....Validate SED_params: {} not found".format(k))
+            check = False
+
+    return check
+
+
+def substitute_SFH_fit_failures(
+    dc2,
+    SED_params,
+    source_galaxy_tag,
+    seed,
+    cosmology,
+    snapshot_redshift,
+    mah_keys="mah_keys",
+    ms_keys="ms_keys",
+    q_keys="q_keys",
+):
+    # check for fit failures
+    has_fit = dc2[source_galaxy_tag + "has_fit"] == 1
+    # check for replacement
+    nfail = np.count_nonzero(~has_fit)
+    nmissed = -1
+    use_diffmah_pop = SED_params["use_diffmah_pop"]
+    if source_galaxy_tag + "nofit_replace" in dc2.colnames:
+        nofit_replace = dc2[source_galaxy_tag + "nofit_replace"][~has_fit] == 1
+        n_replace = np.count_nonzero(nofit_replace)
+        if n_replace > 0:
+            msg = ".....Replaced {} diffmah/diffstar fit failures with {}"
+            print("{} resampled UM fit successes".format(msg.format(nfail, n_replace)))
+        else:
+            msg = ".....No replacements required; {} fit failures, {} replacements"
+            print(msg.format(nfail, n_replace))
+        nmissed = nfail - n_replace
+    if nmissed > 0 or (nmissed < 0 and nfail > 0) or (use_diffmah_pop and nfail > 0):
+        msg = ".....Replacing parameters for {} fit failures with diffmah{} pop"
+        if nmissed > 0 and not use_diffmah_pop:
+            failed_mask = ~nofit_replace
+            print(".......{}".format(msg.format(nmissed, "/diffstar")))
+        else:
+            failed_mask = ~has_fit
+            txt = "" if use_diffmah_pop else "/diffstar"
+            print(".......{}".format(msg.format(nfail, txt)))
+
+        logmh = np.array(np.log10(dc2["target_halo_mass"][failed_mask]))
+        logmh = logmh.astype(np.float32)
+        ran_key = jran.PRNGKey(seed)
+        t_obs = cosmology.age(snapshot_redshift).value
+        mc_galpop = mc_diffstarpop(ran_key, t_obs, logmh=logmh)
+        mc_mah_params, mc_msk_is_quenched, mc_ms_params, mc_q_params = mc_galpop
+        # copy requested mc_params to dc2 table
+        key_labels = [mah_keys] if use_diffmah_pop else [mah_keys, ms_keys, q_keys]
+        mc_parlist = (
+            [mc_mah_params]
+            if use_diffmah_pop
+            else [mc_mah_params, mc_ms_params, mc_q_params]
+        )
+        for key_label, mc_params in zip(key_labels, mc_parlist):
+            for i, key in enumerate(
+                SED_params[key_label]
+            ):  # potential bug here if some other subset of fit params selected
+                dc2[key][failed_mask] = mc_params[:, i]
+                print(".......saving pop model parameters {}".format(key))
+
+    return dc2
+
+
+def save_sed_info(dc2, _res, SED_params):
+    gal_weights, gal_frac_trans_obs, gal_frac_trans_rest = _res[:3]
+    gal_att_curve_params = _res[3]
+    gal_frac_unobs, gal_fburst, gal_burstshape_params = _res[4:7]
+    gal_frac_bulge_t_obs, gal_fbulge_params, gal_fknot = _res[7:10]
+    gal_obsmags_nodust, gal_restmags_nodust = _res[10:12]
+    gal_obsmags_dust, gal_restmags_dust = _res[12:]
+
+    # add values to catalog
+    dc2["dust_eb"] = gal_att_curve_params[:, 0]
+    dc2["dust_delta"] = gal_att_curve_params[:, 1]
+    dc2["dust_av"] = gal_att_curve_params[:, 2]
+    dc2["fburst"] = gal_fburst
+    dc2["burstshape_lgyr_peak"] = gal_burstshape_params[:, 0]
+    dc2["burstshape_lgyr_max"] = gal_burstshape_params[:, 1]
+    dc2["bulge_frac"] = gal_frac_bulge_t_obs
+    dc2["fbulge_tcrit"] = gal_fbulge_params[:, 0]
+    dc2["fbulge_early"] = gal_fbulge_params[:, 1]
+    dc2["fbulge_late"] = gal_fbulge_params[:, 2]
+    dc2["fknot"] = gal_fknot
+
+    for dustlabel, results in zip(
+        ["", "_nodust"],
+        [
+            [gal_restmags_dust, gal_obsmags_dust],
+            [gal_restmags_nodust, gal_obsmags_nodust],
+        ],
+    ):
+        for fr, vals in zip(["rest", "obs"], results):
+            for k in SED_params["filter_keys"]:
+                filt = k.split("_")[0]
+                band = k.split("_")[1]
+                band = band.upper() if fr == "rest" else band
+                colname = "{}_{}_{}{}".format(filt, fr, band, dustlabel)
+                column = SED_params["filter_keys"].index(k)
+                dc2[colname] = vals[:, column]
+
+    return dc2
+
+
+def get_galaxy_sizes(SDSS_R, redshift, cosmology):
+    if len(redshift) > 0:
+        arcsec_per_kpc = cosmology.arcsec_per_kpc_proper(redshift).value
+    else:
+        arcsec_per_kpc = np.zeros(0, dtype=np.float)
+
+    size_disk = mc_size_vs_luminosity_late_type(SDSS_R, redshift)
+    size_sphere = mc_size_vs_luminosity_early_type(SDSS_R, redshift)
+    return size_disk, size_sphere, arcsec_per_kpc
+
+
+def get_sky_coords(
+    dc2, cosmology, redshift_method="halo", Nzgrid=50, source_galaxy_tag="source_galaxy"
+):
+    #  compute galaxy redshift, ra and dec
+    if redshift_method is not None:
+        print(
+            "\n.....Generating lightcone redshifts using {} method".format(
+                redshift_method
+            )
+        )
+        r = np.sqrt(dc2["x"] * dc2["x"] + dc2["y"] * dc2["y"] + dc2["z"] * dc2["z"])
+        mask = r > 5000.0
+        if np.sum(mask) > 0:
+            print("WARNING: Found {} co-moving distances > 5000".format(np.sum(mask)))
+
+        dc2["redshift"] = dc2["target_halo_redshift"]  # copy halo redshifts to galaxies
+        H0 = cosmology.H0.value
+        if redshift_method == "galaxy":
+            #  generate distance estimates for values between min and max redshifts
+            zmin = np.min(dc2["redshift"])
+            zmax = np.max(dc2["redshift"])
+            zgrid = np.logspace(np.log10(zmin), np.log10(zmax), Nzgrid)
+            CDgrid = cosmology.comoving_distance(zgrid) * H0 / 100.0
+            #  use interpolation to get redshifts for satellites only
+            sat_mask = dc2[source_galaxy_tag + "upid"] != -1
+            dc2["redshift"][sat_mask] = np.interp(r[sat_mask], CDgrid, zgrid)
+
+        dc2["dec"] = 90.0 - np.arccos(dc2["z"] / r) * 180.0 / np.pi  # co-latitude
+        dc2["ra"] = np.arctan2(dc2["y"], dc2["x"]) * 180.0 / np.pi
+        dc2["ra"][(dc2["ra"] < 0)] += 360.0  # force value 0->360
+
+        print(
+            ".......min/max z for shell: {:.3f}/{:.3f}".format(
+                np.min(dc2["redshift"]), np.max(dc2["redshift"])
+            )
+        )
+    return dc2
+
+
+def get_skyarea(output_mock, Nside):
+    """ """
+    import healpy as hp
+
+    #  compute sky area from ra and dec ranges of galaxies
+    nominal_skyarea = np.rad2deg(np.rad2deg(4.0 * np.pi / hp.nside2npix(Nside)))
+    if Nside > 8:
+        skyarea = nominal_skyarea
+    else:
+        pixels = set()
+        for k in output_mock.keys():
+            if output_mock[k].has_key("ra") and output_mock[k].has_key("dec"):
+                for ra, dec in zip(output_mock[k]["ra"], output_mock[k]["dec"]):
+                    pixels.add(hp.ang2pix(Nside, ra, dec, lonlat=True))
+        frac = len(pixels) / float(hp.nside2npix(Nside))
+        skyarea = frac * np.rad2deg(np.rad2deg(4.0 * np.pi))
+        # agreement to about 1 sq. deg.
+        if np.isclose(skyarea, nominal_skyarea, rtol=0.02):
+            print(" Replacing calculated sky area {} with nominal_area".format(skyarea))
+            skyarea = nominal_skyarea
+        if np.isclose(
+            skyarea, nominal_skyarea / 2.0, rtol=0.01
+        ):  # check for half-filled pixels
+            print(
+                " Replacing calculated sky area {} with (nominal_area)/2".format(
+                    skyarea
+                )
+            )
+            skyarea = nominal_skyarea / 2.0
+
+    return skyarea
+
+
+def write_output_mock_to_disk(
+    output_color_mock_fname,
+    output_mock,
+    commit_hash,
+    seed,
+    synthetic_params,
+    cutout_number,
+    Nside,
+    cosmology,
+    versionMajor=1,
+    versionMinor=1,
+    versionMinorMinor=1,
+):
+    """
+    Write the assembled mock to specified output file in hdf5 format
+    """
+
+    print(
+        "\n...Writing to file {} using commit hash {}".format(
+            output_color_mock_fname, commit_hash
+        )
+    )
+    hdfFile = h5py.File(output_color_mock_fname, "w")
+    hdfFile.create_group("metaData")
+    hdfFile["metaData"]["commit_hash"] = commit_hash
+    hdfFile["metaData"]["seed"] = seed
+    hdfFile["metaData"]["versionMajor"] = versionMajor
+    hdfFile["metaData"]["versionMinor"] = versionMinor
+    hdfFile["metaData"]["versionMinorMinor"] = versionMinorMinor
+    hdfFile["metaData"]["H_0"] = cosmology.H0.value
+    hdfFile["metaData"]["Omega_matter"] = cosmology.Om0
+    hdfFile["metaData"]["Omega_b"] = cosmology.Ob0
+    hdfFile["metaData"]["skyArea"] = get_skyarea(output_mock, Nside)
+    hdfFile["metaData"]["healpix_cutout_number"] = cutout_number
+    if synthetic_params and not synthetic_params["skip_synthetics"]:
+        synthetic_halo_minimum_mass = synthetic_params["synthetic_halo_minimum_mass"]
+        hdfFile["metaData"]["synthetic_halo_minimum_mass"] = synthetic_halo_minimum_mass
+
+    for k, v in output_mock.items():
+        gGroup = hdfFile.create_group(k)
+        check_time = time()
+        for tk in v.keys():
+            # gGroup[tk] = v[tk].quantity.value
+            gGroup[tk] = v[tk]
+
+        print(
+            ".....time to write group {} = {:.4f} secs".format(k, time() - check_time)
+        )
+
+    check_time = time()
+    hdfFile.close()
+    print(".....time to close file {:.4f} secs".format(time() - check_time))
+    print(".....time to close file {:.4f} secs".format(time() - check_time))


### PR DESCRIPTION
This PR brings in several new modules for making mocks in which all galaxies have solar metallicity. The new mocks are based on SSP SEDs with no metallicity dimension. These SSPs are stored in the same [DSPS data location](https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/) as before, but now with the basename `ssp_data_fsps_v3.2_age.h5` rather than `ssp_data_fsps_v3.2_lgmet_age.h5`. This should substantially reduce our memory footprint in the SED computations, since previously the metallicity dimension has 12 grid points.

@evevkovacs there is a new script to use when making single-metallicity mocks, [write_mock_to_disk_singlemet.py](https://github.com/LSSTDESC/lsstdesc-diffsky/blob/2fc592fcebd6c66029bb84bd4d477d0eaead4f13/lsstdesc_diffsky/write_mock_to_disk_singlemet.py).