### PR TITLE
Log safe ssfr fix

### DIFF
--- a/lsstdesc_diffsky/tests/test_get_log_safe_ssfr.py
+++ b/lsstdesc_diffsky/tests/test_get_log_safe_ssfr.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from ..photometry.get_SFH_from_params import get_log_safe_ssfr
 
-Ngals = 100
+Ngals = 1_000_000
 Mstar = 1e10
 SFR = 1e11
 
@@ -19,6 +19,4 @@ def test_get_log_safe_ssfr():
     assert np.all(np.isfinite(log_ssfr))
     assert log_ssfr.shape == (Ngals,)
     assert np.all(log_ssfr[0 : int(Ngals / 2)] == 1)
-    assert np.all(log_ssfr[int(Ngals / 2) :] < -11)
-
-    return
+    assert np.all(log_ssfr[int(Ngals / 2) :] < -7)

--- a/lsstdesc_diffsky/tests/test_get_log_safe_ssfr.py
+++ b/lsstdesc_diffsky/tests/test_get_log_safe_ssfr.py
@@ -1,6 +1,7 @@
 """
 """
 import numpy as np
+
 from ..photometry.get_SFH_from_params import get_log_safe_ssfr
 
 Ngals = 100
@@ -10,14 +11,14 @@ SFR = 1e11
 
 def test_get_log_safe_ssfr():
     # setup arrays
-    mstar = np.array([Mstar]*Ngals)
+    mstar = np.array([Mstar] * Ngals)
     sfr = np.zeros(Ngals)
     # replace selected values with finite values
-    sfr[0:int(Ngals/2)] = SFR
+    sfr[0 : int(Ngals / 2)] = SFR
     log_ssfr = get_log_safe_ssfr(mstar, sfr)
     assert np.all(np.isfinite(log_ssfr))
     assert log_ssfr.shape == (Ngals,)
-    assert np.all(log_ssfr[0:int(Ngals/2)] == 1)
-    assert np.all(log_ssfr[int(Ngals/2):] < -11)
+    assert np.all(log_ssfr[0 : int(Ngals / 2)] == 1)
+    assert np.all(log_ssfr[int(Ngals / 2) :] < -11)
 
     return


### PR DESCRIPTION
This PR fixes a bug in the formulation of `test_get_log_safe_ssfr`. The behavior of the `get_log_safe_ssfr` function is stochastic, and so the way this test was written, it sometimes fails and it sometimes passes, depending on the random number generator (this failure was caught [here](https://github.com/LSSTDESC/lsstdesc-diffsky/actions/runs/6651246475/job/18072899046#step:5:195) during our semi-weekly cron test, but not in the workflow run at the time of the PR). I have fixed this in two ways:
1. I increased the number of tested points to 1e6 so that it *always* fails as it was originally written
2. I relaxed the tolerance on the expectation of the returned values so that the random number generator never returns a value below the expected tolerance

@evevkovacs 