### PR TITLE
Bug-fixes for size outliers and bulge fraction NaNs

### DIFF
--- a/lsstdesc_diffsky/constants.py
+++ b/lsstdesc_diffsky/constants.py
@@ -1,6 +1,8 @@
 """This module stores globals used throughout the repository."""
 from copy import deepcopy
 
+from dsps.constants import T_TABLE_MIN
+
 from .disk_bulge_modeling.disk_bulge_kernels import DEFAULT_FBULGE_PDICT
 
 MAH_PNAMES = [
@@ -31,7 +33,7 @@ SED_params = {
     "q_keys": Q_PNAMES,
     "sfh_keys": ["mstar", "sfr", "fstar", "dmhdt", "log_mah"],
     "z0": 0.0,
-    "t_start": 0.05,
+    "t_start": T_TABLE_MIN,
     "N_t": 100,
     "xkeys": [
         "ssp_z_table",

--- a/lsstdesc_diffsky/size_modeling/zhang_yang17.py
+++ b/lsstdesc_diffsky/size_modeling/zhang_yang17.py
@@ -4,6 +4,7 @@ taken from Zhang & Yang (2017), arXiv:1707.04979.
 import numpy as np
 from astropy.utils.misc import NumpyRNGContext
 
+MAX_SIZE = 100.0  # kpc
 
 __all__ = (
     "median_size_vs_luminosity_late_type",
@@ -77,7 +78,9 @@ def median_size_vs_luminosity(magr, redshift, gamma, alpha, beta, mzero):
     luminosity = 10 ** (-0.4 * (magr - mzero))
     z0_size = gamma * (luminosity**alpha) * ((1.0 + luminosity) ** (beta - alpha))
     shrinking_factor = redshift_shrinking_factor(redshift)
-    return z0_size / shrinking_factor
+    size = z0_size / shrinking_factor
+    size = np.where(size > MAX_SIZE, MAX_SIZE, size)
+    return size
 
 
 def median_size_vs_luminosity_early_type(

--- a/lsstdesc_diffsky/tests/test_constants.py
+++ b/lsstdesc_diffsky/tests/test_constants.py
@@ -50,7 +50,7 @@ def test_SED_params_contents():
         "q_keys": constants.Q_PNAMES,
         "sfh_keys": ["mstar", "sfr", "fstar", "dmhdt", "log_mah"],
         "z0": 0.0,
-        "t_start": 0.05,
+        "t_start": 0.01,
         "N_t": 100,
         "xkeys": [
             "ssp_z_table",


### PR DESCRIPTION
This PR implements a clip in the median size relation so that the maximum allowable half-light radius of any component is no more than 100 kpc. This PR also sets `SED_params['t_start']` to `dsps.constants.T_TABLE_MIN`. 

cc @evevkovacs 