### PR TITLE
Add monthly cron to test for deprecation warnings

### DIFF
--- a/.github/workflows/monthly-warning-test.yml
+++ b/.github/workflows/monthly-warning-test.yml
@@ -1,0 +1,58 @@
+name: Test for Warnings
+
+on:
+  workflow_dispatch: null
+  schedule:
+    # Runs "First of every month at 3:15am Central"
+    - cron: '15 8 1 * *'
+  push:
+    branches:
+      - main
+  pull_request: null
+
+jobs:
+  tests:
+    name: tests
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.9
+          channels: conda-forge,defaults
+          channel-priority: strict
+          show-channel-urls: true
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          use-mamba: true
+
+      - name: configure conda and install code
+      # Test against pinned versions of diffmah, diffstar, and dsps
+        shell: bash -l {0}
+        run: |
+          conda config --set always_yes yes
+          mamba install --quiet \
+            --file=requirements.txt
+          python -m pip install -e .
+          mamba install -y -q \
+            flake8 \
+            pytest \
+            pytest-xdist \
+            pytest-cov \
+            pip \
+            setuptools \
+            "setuptools_scm>=7,<8" \
+            python-build
+          pip uninstall dsps --yes
+          pip install --no-deps dsps
+          python -m pip install --no-build-isolation --no-deps -e .
+
+      - name: test that no warnings are raised
+        shell: bash -l {0}
+        run: |
+          export PYTHONWARNINGS=error
+          pytest -v lsstdesc_diffsky --cov --cov-report=xml

--- a/README.rst
+++ b/README.rst
@@ -61,3 +61,4 @@ you will also need to install a python kernel as follows::
 `demo_load_catalog <https://github.com/LSSTDESC/lsstdesc-diffsky/tree/main/notebooks/demo_load_catalog.ipynb>`_
 is a demo notebook showing how to load the catalog from a notebook running at NERSC 
 and perform some basic operations.
+


### PR DESCRIPTION
This PR brings in a new CI testing workflow that runs automatically every month as a cron job. This workflow is different from our standard tests.yml because any warning raised during the execution of the test suite will be treated as a test failure. This CI cron thus notifies us whenever upstream changes in JAX, numpy, etc., impact our source code.